### PR TITLE
fix(usd): address Phase 1 PR review — LFS skip, rename composedLayers, pin rev, stable key, dedup issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ artifacts/logs/*
 
 samples/private/*
 !samples/private/.gitkeep
+
+experiments/

--- a/docs/usd-phase0.md
+++ b/docs/usd-phase0.md
@@ -1,0 +1,151 @@
+# USD Phase 0 PoC レポート
+
+## 目的
+
+`yw-look` の USD 対応方針 (`表示は Three.js / 検査は Rust`) を踏まえ、Rust 側 inspector の実装基盤として `mxpv/openusd` (crates.io: `openusd 0.2.0`) が使えるかを **fork する前に** 確認する。
+
+判断したいこと:
+
+- USDA / USDC / USDZ が現実のアセットで読めるか
+- composition (`references` / `payloads` / `subLayers`) が動くか
+- Windows MSVC でビルドが通るか
+- `inspect_stage` / `summarize_stage` / `collect_asset_issues` を組める API があるか
+- fork して足すべき機能の見積もり
+
+## 検証環境
+
+- OS: Windows 11
+- Toolchain: `rustc 1.94.0` / `cargo 1.94.0` (stable-x86_64-pc-windows-msvc)
+- Crate: `openusd = "0.2"` (released 2026-04-06)
+- PoC コード: `experiments/usd-poc/` (yw-look 本体から隔離した独立 Cargo project)
+
+## ビルド事情
+
+- `openusd 0.2` の依存ツリーは **pure Rust のみ**
+- 主要な transitive deps: `memchr`, `log`, `simd-adler32`, `fnv`, `hashbrown`, `anyhow`, `typed-path`, `heck`, `equivalent`
+- C++ FFI (`bindgen`, `cmake`, `cc`, `openssl-sys`) なし
+- Windows MSVC で build / run まで成功
+
+これは「OpenUSD C++ ラッパー系の crate にありがちな Windows ビルド地獄」を回避できていることを意味し、yw-look の配布要件と相性が良い。
+
+## 検証アセット
+
+| ID | パス | 形式 | 性質 |
+|---|---|---|---|
+| `usda-tiny-sanity` | `samples/assets/usd/tiny.usda` | USDA 単体 | 自作 sanity asset。`defaultPrim` / `upAxis` / `metersPerUnit` 明示 |
+| `usd-kitchen-set` | `samples/private/usd/Kitchen_set/Kitchen_set/Kitchen_set.usd` | USDA root + USDC `*.geom.usd` | Pixar Kitchen Set。`references` と `payloads` 多用 |
+| `usd-kitchen-set-instanced` | `Kitchen_set_instanced.usd` | USDA + native instancing | `instanceable = true` を使う variant |
+| `usdz-arkit-chameleon` | `chameleon_anim_mtl_variant.usdz` | USDZ (ZIP) | Apple AR Quick Look サンプル。アニメ + variant |
+| `usdz-arkit-glove` | `glove_baseball_mtl_variant.usdz` | USDZ (ZIP) | Apple AR Quick Look サンプル。variant |
+
+## 結果マトリクス
+
+| アセット | `Stage::open` | `default_prim` | `layer_count` | `root_prims` | `traverse` 完走 prim 数 |
+|---|---|---|---|---|---|
+| `tiny.usda` | ✅ | `"Root"` | 1 | 1 | 2 |
+| `Kitchen_set.usd` | ✅ | `"Kitchen_set"` | **229** | 77 | **2048** |
+| `Kitchen_set_instanced.usd` | ❌ | — | — | — | — |
+| `chameleon_anim_mtl_variant.usdz` | ✅ | `"Root"` | 1 | 1 | 203 |
+| `glove_baseball_mtl_variant.usdz` | ✅ | `"glove_baseball"` | 1 | 1 | 67 |
+
+### Kitchen Set の意味
+
+`layer_count = 229` で composed されたことは大きい。これが意味するのは:
+
+- USDA root layer がパースされた
+- 参照先の `*.geom.usd` (USDC binary, 228 個) が再帰的に解決された
+- `references` と `payloads` を辿って composition tree に組み込めた
+- 77 root prims / 2048 prims の depth-first traverse が完走した
+
+USDA + USDC + composition arc がすべて動く 1 つの実証ケース。
+
+### 唯一の失敗
+
+`Kitchen_set_instanced.usd` は次のエラーで `Stage::open` に失敗:
+
+```
+failed to parse USDA layer
+Caused by:
+    0: Unable to parse prim metadata
+    1: Unable to parse prim metadata entry
+    2: Unsupported prim metadata: instanceable
+```
+
+USDA parser が prim metadata の `instanceable = true` をまだ知らない。アーキテクチャの欠陥ではなく、parser の認識キーが 1 つ足りないだけ。**upstream PR 1 本で塞げる粒度**。
+
+## API 観察
+
+### 直接 accessor が存在するもの
+
+| 機能 | API |
+|---|---|
+| stage を開く | `Stage::open(&resolver, path) -> Result<Self>` |
+| `defaultPrim` 読み | `stage.default_prim() -> Option<String>` |
+| 合成済みレイヤ列挙 | `stage.layer_identifiers() -> &[String]` |
+| レイヤ数 | `stage.layer_count() -> usize` |
+| root prim 列挙 | `stage.root_prims() -> Result<Vec<String>>` |
+| prim 走査 | `stage.traverse(visitor) -> Result<()>` |
+| 汎用 metadata 読み | `stage.field::<T>(path, field) -> Result<Option<T>>` |
+| spec 種別 | `stage.spec_type(path) -> Option<SpecType>` |
+| asset resolver | `ar::DefaultResolver::new()` |
+
+### 汎用 API 経由が必要なもの (= fork PR の自然な単位)
+
+| 機能 | 現状 | 提案する upstream PR |
+|---|---|---|
+| `upAxis` 読み | `stage.field::<String>(...)` で取れるはず | `stage.up_axis() -> Option<UpAxis>` |
+| `metersPerUnit` 読み | 同上 | `stage.meters_per_unit() -> Option<f64>` |
+| `references` 列挙 | 自前で field 経由 | `stage.references_in(path) -> Vec<Reference>` |
+| `payloads` 列挙 | 自前で field 経由 | `stage.payloads_in(path) -> Vec<Payload>` |
+| 解決失敗アセット検出 | resolver 越しに自前で確認 | `stage.unresolved_assets() -> Vec<String>` |
+| `instanceable` prim metadata | USDA parser で未対応 | parser に metadata key 追加 |
+
+## 判定: **Go**
+
+- 実アセット 5 件中 4 件が動作
+- USDA / USDC / USDZ / references / payloads が全て 1 つの crate で実証済み
+- Windows MSVC ビルドの障害なし
+- 失敗ケース 1 件は upstream PR 1 本で塞げる粒度
+- 直接 accessor がない項目もすべて generic `field()` 経由で実装可能
+
+Phase 1 へ進む。
+
+## Phase 1 に持ち込むべきこと
+
+### Fork で最初に投入する PR (upstream にも価値があるもの)
+
+1. **`instanceable` prim metadata 対応** — USDA parser の認識キー追加。検証アセット: `Kitchen_set_instanced.usd`
+2. **`stage.up_axis()` accessor** — root layer の `upAxis` を `enum UpAxis { Y, Z }` で返す
+3. **`stage.meters_per_unit()` accessor** — root layer の `metersPerUnit` を `f64` で返す
+4. **`stage.references_in(path)` / `payloads_in(path)`** — composition arc の列挙 API
+5. **`stage.unresolved_assets()`** — resolver で解決できなかった asset path のリスト
+
+### yw-look 側で先に作るもの
+
+- `UsdBackend` trait (`src-tauri/src/usd/backend.rs`) — 抽象境界
+- `OpenusdBackend` 実装 — fork 版 `openusd` を呼ぶ
+- Tauri command `inspect_stage` / `summarize_stage` / `collect_asset_issues`
+- フロントエンド側 USD インスペクタ UI (Phase 1 後半)
+
+### Phase 2 (UX) に積む宿題
+
+PoC で扱った範囲ではないが、計画上忘れない:
+
+- Three.js `USDLoader().parse(buffer)` の同期ブロッキングを崩す
+  - 最低でも summary 表示後に Three.js parse を開始
+  - 可能なら Web Worker への分離
+
+## Exit rule (再掲)
+
+- upstream PR 5 本のうち過半が 3 ヶ月以内に merge されない、もしくは USDC 系のクリティカルな破綻が判明した場合 → fork 常用をやめ、`yw-look/src-tauri` 側に必要最小限の inspector を inline で持つ方針に切り替える
+- その判断ポイントは Phase 1 の中盤 (PR 提出から 6 週後) に一度レビューする
+
+## 再現手順
+
+```sh
+# Phase 0 PoC を再実行する
+cd experiments/usd-poc
+cargo run --release
+```
+
+引数を省略すると `samples/` 配下の Phase 0 アセットを順に開く。個別アセットは `cargo run --release -- <path>` で指定できる。

--- a/samples/assets/usd/tiny.usda
+++ b/samples/assets/usd/tiny.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a37395907c09b7105aaab430f88e3a32986a6c89574c80fd0e5006e838cddd24
+oid sha256:ebf379ee88a963d155762e333e5ac08cd9313dedf4c8b3c5bd5337554ef60347
 size 473

--- a/samples/assets/usd/tiny.usda
+++ b/samples/assets/usd/tiny.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37395907c09b7105aaab430f88e3a32986a6c89574c80fd0e5006e838cddd24
+size 473

--- a/samples/manifest.json
+++ b/samples/manifest.json
@@ -162,6 +162,71 @@
         "shouldLoad": true,
         "hasMetadata": true
       }
+    },
+    {
+      "id": "usda-tiny-sanity",
+      "kind": "model",
+      "format": "usda",
+      "path": "samples/assets/usd/tiny.usda",
+      "tags": ["usd", "usda", "phase0", "sanity"],
+      "phase": "phase0",
+      "expect": {
+        "shouldLoad": true,
+        "defaultPrim": "Root",
+        "upAxis": "Y",
+        "metersPerUnit": 0.01,
+        "hasReferences": false,
+        "hasPayloads": false,
+        "hasSubLayers": false
+      }
+    },
+    {
+      "id": "usd-kitchen-set",
+      "kind": "model",
+      "format": "usd",
+      "path": "samples/private/usd/Kitchen_set/Kitchen_set/Kitchen_set.usd",
+      "tags": ["usd", "usda", "usdc", "phase0", "composition", "private"],
+      "phase": "phase0",
+      "private": true,
+      "license": "Pixar Kitchen Set License (research / non-commercial)",
+      "notes": "Root is USDA. Per-asset *.geom.usd files are USDC binary. Heavy references and payloads.",
+      "expect": {
+        "shouldLoad": true,
+        "defaultPrim": "Kitchen_set",
+        "upAxis": "Z",
+        "hasReferences": true,
+        "hasPayloads": true,
+        "hasSubLayers": false,
+        "mixesUsdaAndUsdc": true
+      }
+    },
+    {
+      "id": "usdz-arkit-chameleon",
+      "kind": "model",
+      "format": "usdz",
+      "path": "samples/private/usd/chameleon_anim_mtl_variant.usdz",
+      "tags": ["usd", "usdz", "phase0", "zip", "private"],
+      "phase": "phase0",
+      "private": true,
+      "license": "Apple AR Quick Look sample (developer.apple.com)",
+      "expect": {
+        "shouldLoad": true,
+        "isZipContainer": true
+      }
+    },
+    {
+      "id": "usdz-arkit-glove",
+      "kind": "model",
+      "format": "usdz",
+      "path": "samples/private/usd/glove_baseball_mtl_variant.usdz",
+      "tags": ["usd", "usdz", "phase0", "zip", "private"],
+      "phase": "phase0",
+      "private": true,
+      "license": "Apple AR Quick Look sample (developer.apple.com)",
+      "expect": {
+        "shouldLoad": true,
+        "isZipContainer": true
+      }
     }
   ]
 }

--- a/samples/sources.md
+++ b/samples/sources.md
@@ -14,8 +14,23 @@
 - `samples/assets/stl/TinyTetrahedronAscii.stl`
   Source: handcrafted ASCII tetrahedron for lightweight STL checks
 
+## USD Phase 0 PoC assets
+
+- `samples/assets/usd/tiny.usda`
+  Hand-written sanity asset. Single-file USDA with explicit `defaultPrim` / `upAxis` / `metersPerUnit`.
+  Committed to the repo.
+- `samples/private/usd/Kitchen_set/`
+  Pixar Kitchen Set. Root is USDA, per-asset `*.geom.usd` files are USDC binary. Rich `references` and `payloads`.
+  Source: https://openusd.org/release/dl_kitchen_set.html
+  License: Pixar research / non-commercial. NOT committed.
+- `samples/private/usd/chameleon_anim_mtl_variant.usdz`, `glove_baseball_mtl_variant.usdz`
+  Apple AR Quick Look samples (USDZ ZIP container).
+  Source: https://developer.apple.com/augmented-reality/quick-look/
+  NOT committed.
+
 ## Notes
 
 - These files are for local verification and debugging.
 - Some formats are represented by a single small sample for now.
 - Additional cases should be added over time for broken references, embedded textures, heavy files, and failure cases.
+- Anything under `samples/private/` is excluded from git; obtain it from the upstream source listed above.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -371,6 +371,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -616,6 +630,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1054,6 +1074,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1515,6 +1536,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2056,6 +2090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2133,47 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "mac"
@@ -2266,6 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2437,6 +2519,21 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openusd"
+version = "0.2.0"
+source = "git+https://github.com/yohawing/openusd.git?branch=yw-look-phase1#d924cac8cc5d84043873c3700f85c616ea99b330"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "half",
+ "logos",
+ "lz4_flex",
+ "num-traits",
+ "strum",
+ "zip 8.5.0",
+]
 
 [[package]]
 name = "option-ext"
@@ -3810,6 +3907,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,7 +4226,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -4571,6 +4689,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -5736,6 +5866,7 @@ dependencies = [
 name = "yw-look"
 version = "0.1.0"
 dependencies = [
+ "openusd",
  "rfd",
  "serde",
  "serde_json",
@@ -5899,10 +6030,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.1",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2523,7 +2523,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 [[package]]
 name = "openusd"
 version = "0.2.0"
-source = "git+https://github.com/yohawing/openusd.git?branch=yw-look-phase1#d924cac8cc5d84043873c3700f85c616ea99b330"
+source = "git+https://github.com/yohawing/openusd.git?rev=d924cac8cc5d84043873c3700f85c616ea99b330#d924cac8cc5d84043873c3700f85c616ea99b330"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.1.0", features = [] }
 
 [dependencies]
-openusd = { git = "https://github.com/yohawing/openusd.git", branch = "yw-look-phase1" }
+openusd = { git = "https://github.com/yohawing/openusd.git", rev = "d924cac8cc5d84043873c3700f85c616ea99b330" }
 rfd = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.1.0", features = [] }
 
 [dependencies]
+openusd = { git = "https://github.com/yohawing/openusd.git", branch = "yw-look-phase1" }
 rfd = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/gen/schemas/linux-schema.json
+++ b/src-tauri/gen/schemas/linux-schema.json
@@ -1,0 +1,2298 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CapabilityFile",
+  "description": "Capability formats accepted in a capability file.",
+  "anyOf": [
+    {
+      "description": "A single capability.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Capability"
+        }
+      ]
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Capability"
+      }
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "object",
+      "required": [
+        "capabilities"
+      ],
+      "properties": {
+        "capabilities": {
+          "description": "The list of capabilities.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "Capability": {
+      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows' and webviews' fine grained access to the Tauri core, application, or plugin commands. If a webview or its window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, ], \"platforms\": [\"macOS\",\"windows\"] } ```",
+      "type": "object",
+      "required": [
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "Identifier of the capability.\n\n## Example\n\n`main-user-files-write`",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of what the capability is intended to allow on associated windows.\n\nIt should contain a description of what the grouped permissions should allow.\n\n## Example\n\nThis capability allows the `main` window access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.",
+          "default": "",
+          "type": "string"
+        },
+        "remote": {
+          "description": "Configure remote URLs that can use the capability permissions.\n\nThis setting is optional and defaults to not being set, as our default use case is that the content is served from our local application.\n\n:::caution Make sure you understand the security implications of providing remote sources with local system access. :::\n\n## Example\n\n```json { \"urls\": [\"https://*.mydomain.dev\"] } ```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CapabilityRemote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "local": {
+          "description": "Whether this capability is enabled for local app URLs or not. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
+        },
+        "windows": {
+          "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\nIf a window label matches any of the patterns in this list, the capability will be enabled on all the webviews of that window, regardless of the value of [`Self::webviews`].\n\nOn multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`] for a fine grained access control.\n\n## Example\n\n`[\"main\"]`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "webviews": {
+          "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\nThe capability will be enabled on all the webviews whose label matches any of the patterns in this list, regardless of whether the webview's window label matches a pattern in [`Self::windows`].\n\n## Example\n\n`[\"sub-webview-one\", \"sub-webview-two\"]`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ] ```",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionEntry"
+          },
+          "uniqueItems": true
+        },
+        "platforms": {
+          "description": "Limit which target platforms this capability applies to.\n\nBy default all platforms are targeted.\n\n## Example\n\n`[\"macOS\",\"windows\"]`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "CapabilityRemote": {
+      "description": "Configuration for remote URLs that are associated with the capability.",
+      "type": "object",
+      "required": [
+        "urls"
+      ],
+      "properties": {
+        "urls": {
+          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).\n\n## Examples\n\n- \"https://*.mydomain.dev\": allows subdomains of mydomain.dev - \"https://mydomain.dev/api/*\": allows any subpath of mydomain.dev/api",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionEntry": {
+      "description": "An entry for a permission value in a [`Capability`] can be either a raw permission [`Identifier`] or an object that references a permission and extends its scope.",
+      "anyOf": [
+        {
+          "description": "Reference a permission or permission set by identifier.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
+        },
+        {
+          "description": "Reference a permission or permission set by identifier and extends its scope.",
+          "type": "object",
+          "allOf": [
+            {
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Identifier"
+                    }
+                  ]
+                },
+                "allow": {
+                  "description": "Data that defines what is allowed by the scope.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Value"
+                  }
+                },
+                "deny": {
+                  "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Value"
+                  }
+                }
+              }
+            }
+          ],
+          "required": [
+            "identifier"
+          ]
+        }
+      ]
+    },
+    "Identifier": {
+      "description": "Permission identifier",
+      "oneOf": [
+        {
+          "description": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`",
+          "type": "string",
+          "const": "core:default",
+          "markdownDescription": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`"
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`",
+          "type": "string",
+          "const": "core:app:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`"
+        },
+        {
+          "description": "Enables the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-app-hide",
+          "markdownDescription": "Enables the app_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the app_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-app-show",
+          "markdownDescription": "Enables the app_show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the bundle_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-bundle-type",
+          "markdownDescription": "Enables the bundle_type command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the default_window_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-default-window-icon",
+          "markdownDescription": "Enables the default_window_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the fetch_data_store_identifiers command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-fetch-data-store-identifiers",
+          "markdownDescription": "Enables the fetch_data_store_identifiers command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-identifier",
+          "markdownDescription": "Enables the identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-name",
+          "markdownDescription": "Enables the name command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-register-listener",
+          "markdownDescription": "Enables the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_data_store command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-remove-data-store",
+          "markdownDescription": "Enables the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-remove-listener",
+          "markdownDescription": "Enables the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_app_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-set-app-theme",
+          "markdownDescription": "Enables the set_app_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_dock_visibility command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-set-dock-visibility",
+          "markdownDescription": "Enables the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-tauri-version",
+          "markdownDescription": "Enables the tauri_version command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-version",
+          "markdownDescription": "Enables the version command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-app-hide",
+          "markdownDescription": "Denies the app_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the app_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-app-show",
+          "markdownDescription": "Denies the app_show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the bundle_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-bundle-type",
+          "markdownDescription": "Denies the bundle_type command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the default_window_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-default-window-icon",
+          "markdownDescription": "Denies the default_window_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the fetch_data_store_identifiers command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-fetch-data-store-identifiers",
+          "markdownDescription": "Denies the fetch_data_store_identifiers command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-identifier",
+          "markdownDescription": "Denies the identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-name",
+          "markdownDescription": "Denies the name command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-register-listener",
+          "markdownDescription": "Denies the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_data_store command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-remove-data-store",
+          "markdownDescription": "Denies the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-remove-listener",
+          "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_app_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-set-app-theme",
+          "markdownDescription": "Denies the set_app_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_dock_visibility command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-set-dock-visibility",
+          "markdownDescription": "Denies the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-tauri-version",
+          "markdownDescription": "Denies the tauri_version command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-version",
+          "markdownDescription": "Denies the version command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-listen`\n- `allow-unlisten`\n- `allow-emit`\n- `allow-emit-to`",
+          "type": "string",
+          "const": "core:event:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-listen`\n- `allow-unlisten`\n- `allow-emit`\n- `allow-emit-to`"
+        },
+        {
+          "description": "Enables the emit command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-emit",
+          "markdownDescription": "Enables the emit command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-emit-to",
+          "markdownDescription": "Enables the emit_to command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the listen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-listen",
+          "markdownDescription": "Enables the listen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-unlisten",
+          "markdownDescription": "Enables the unlisten command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the emit command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-emit",
+          "markdownDescription": "Denies the emit command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-emit-to",
+          "markdownDescription": "Denies the emit_to command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the listen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-listen",
+          "markdownDescription": "Denies the listen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-unlisten",
+          "markdownDescription": "Denies the unlisten command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-from-bytes`\n- `allow-from-path`\n- `allow-rgba`\n- `allow-size`",
+          "type": "string",
+          "const": "core:image:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-from-bytes`\n- `allow-from-path`\n- `allow-rgba`\n- `allow-size`"
+        },
+        {
+          "description": "Enables the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-from-bytes",
+          "markdownDescription": "Enables the from_bytes command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the from_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-from-path",
+          "markdownDescription": "Enables the from_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the rgba command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-rgba",
+          "markdownDescription": "Enables the rgba command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-size",
+          "markdownDescription": "Enables the size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-from-bytes",
+          "markdownDescription": "Denies the from_bytes command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the from_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-from-path",
+          "markdownDescription": "Denies the from_path command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the rgba command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-rgba",
+          "markdownDescription": "Denies the rgba command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-size",
+          "markdownDescription": "Denies the size command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-append`\n- `allow-prepend`\n- `allow-insert`\n- `allow-remove`\n- `allow-remove-at`\n- `allow-items`\n- `allow-get`\n- `allow-popup`\n- `allow-create-default`\n- `allow-set-as-app-menu`\n- `allow-set-as-window-menu`\n- `allow-text`\n- `allow-set-text`\n- `allow-is-enabled`\n- `allow-set-enabled`\n- `allow-set-accelerator`\n- `allow-set-as-windows-menu-for-nsapp`\n- `allow-set-as-help-menu-for-nsapp`\n- `allow-is-checked`\n- `allow-set-checked`\n- `allow-set-icon`",
+          "type": "string",
+          "const": "core:menu:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-append`\n- `allow-prepend`\n- `allow-insert`\n- `allow-remove`\n- `allow-remove-at`\n- `allow-items`\n- `allow-get`\n- `allow-popup`\n- `allow-create-default`\n- `allow-set-as-app-menu`\n- `allow-set-as-window-menu`\n- `allow-text`\n- `allow-set-text`\n- `allow-is-enabled`\n- `allow-set-enabled`\n- `allow-set-accelerator`\n- `allow-set-as-windows-menu-for-nsapp`\n- `allow-set-as-help-menu-for-nsapp`\n- `allow-is-checked`\n- `allow-set-checked`\n- `allow-set-icon`"
+        },
+        {
+          "description": "Enables the append command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-append",
+          "markdownDescription": "Enables the append command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_default command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-create-default",
+          "markdownDescription": "Enables the create_default command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-get",
+          "markdownDescription": "Enables the get command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-insert",
+          "markdownDescription": "Enables the insert command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-is-checked",
+          "markdownDescription": "Enables the is_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-is-enabled",
+          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the items command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-items",
+          "markdownDescription": "Enables the items command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the popup command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-popup",
+          "markdownDescription": "Enables the popup command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the prepend command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-prepend",
+          "markdownDescription": "Enables the prepend command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-remove",
+          "markdownDescription": "Enables the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-remove-at",
+          "markdownDescription": "Enables the remove_at command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-accelerator",
+          "markdownDescription": "Enables the set_accelerator command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-app-menu",
+          "markdownDescription": "Enables the set_as_app_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-help-menu-for-nsapp",
+          "markdownDescription": "Enables the set_as_help_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-window-menu",
+          "markdownDescription": "Enables the set_as_window_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-windows-menu-for-nsapp",
+          "markdownDescription": "Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-checked",
+          "markdownDescription": "Enables the set_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-enabled",
+          "markdownDescription": "Enables the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-text",
+          "markdownDescription": "Enables the set_text command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-text",
+          "markdownDescription": "Enables the text command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the append command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-append",
+          "markdownDescription": "Denies the append command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_default command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-create-default",
+          "markdownDescription": "Denies the create_default command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-get",
+          "markdownDescription": "Denies the get command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-insert",
+          "markdownDescription": "Denies the insert command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-is-checked",
+          "markdownDescription": "Denies the is_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-is-enabled",
+          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the items command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-items",
+          "markdownDescription": "Denies the items command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the popup command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-popup",
+          "markdownDescription": "Denies the popup command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the prepend command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-prepend",
+          "markdownDescription": "Denies the prepend command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-remove",
+          "markdownDescription": "Denies the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-remove-at",
+          "markdownDescription": "Denies the remove_at command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-accelerator",
+          "markdownDescription": "Denies the set_accelerator command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-app-menu",
+          "markdownDescription": "Denies the set_as_app_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-help-menu-for-nsapp",
+          "markdownDescription": "Denies the set_as_help_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-window-menu",
+          "markdownDescription": "Denies the set_as_window_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-windows-menu-for-nsapp",
+          "markdownDescription": "Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-checked",
+          "markdownDescription": "Denies the set_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-enabled",
+          "markdownDescription": "Denies the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-text",
+          "markdownDescription": "Denies the set_text command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-text",
+          "markdownDescription": "Denies the text command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-resolve-directory`\n- `allow-resolve`\n- `allow-normalize`\n- `allow-join`\n- `allow-dirname`\n- `allow-extname`\n- `allow-basename`\n- `allow-is-absolute`",
+          "type": "string",
+          "const": "core:path:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-resolve-directory`\n- `allow-resolve`\n- `allow-normalize`\n- `allow-join`\n- `allow-dirname`\n- `allow-extname`\n- `allow-basename`\n- `allow-is-absolute`"
+        },
+        {
+          "description": "Enables the basename command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-basename",
+          "markdownDescription": "Enables the basename command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the dirname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-dirname",
+          "markdownDescription": "Enables the dirname command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the extname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-extname",
+          "markdownDescription": "Enables the extname command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-is-absolute",
+          "markdownDescription": "Enables the is_absolute command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the join command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-join",
+          "markdownDescription": "Enables the join command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the normalize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-normalize",
+          "markdownDescription": "Enables the normalize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the resolve command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-resolve",
+          "markdownDescription": "Enables the resolve command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-resolve-directory",
+          "markdownDescription": "Enables the resolve_directory command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the basename command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-basename",
+          "markdownDescription": "Denies the basename command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the dirname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-dirname",
+          "markdownDescription": "Denies the dirname command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the extname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-extname",
+          "markdownDescription": "Denies the extname command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-is-absolute",
+          "markdownDescription": "Denies the is_absolute command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the join command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-join",
+          "markdownDescription": "Denies the join command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the normalize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-normalize",
+          "markdownDescription": "Denies the normalize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the resolve command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-resolve",
+          "markdownDescription": "Denies the resolve command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-resolve-directory",
+          "markdownDescription": "Denies the resolve_directory command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-close`",
+          "type": "string",
+          "const": "core:resources:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-close`"
+        },
+        {
+          "description": "Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:resources:allow-close",
+          "markdownDescription": "Enables the close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:resources:deny-close",
+          "markdownDescription": "Denies the close command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`",
+          "type": "string",
+          "const": "core:tray:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`"
+        },
+        {
+          "description": "Enables the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-get-by-id",
+          "markdownDescription": "Enables the get_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-remove-by-id",
+          "markdownDescription": "Enables the remove_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon-as-template",
+          "markdownDescription": "Enables the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-menu",
+          "markdownDescription": "Enables the set_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-show-menu-on-left-click",
+          "markdownDescription": "Enables the set_show_menu_on_left_click command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-temp-dir-path",
+          "markdownDescription": "Enables the set_temp_dir_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-title",
+          "markdownDescription": "Enables the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-tooltip",
+          "markdownDescription": "Enables the set_tooltip command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-visible",
+          "markdownDescription": "Enables the set_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-get-by-id",
+          "markdownDescription": "Denies the get_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-remove-by-id",
+          "markdownDescription": "Denies the remove_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon-as-template",
+          "markdownDescription": "Denies the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-menu",
+          "markdownDescription": "Denies the set_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-show-menu-on-left-click",
+          "markdownDescription": "Denies the set_show_menu_on_left_click command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-temp-dir-path",
+          "markdownDescription": "Denies the set_temp_dir_path command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-title",
+          "markdownDescription": "Denies the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-tooltip",
+          "markdownDescription": "Denies the set_tooltip command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-visible",
+          "markdownDescription": "Denies the set_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-webviews`\n- `allow-webview-position`\n- `allow-webview-size`\n- `allow-internal-toggle-devtools`",
+          "type": "string",
+          "const": "core:webview:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-webviews`\n- `allow-webview-position`\n- `allow-webview-size`\n- `allow-internal-toggle-devtools`"
+        },
+        {
+          "description": "Enables the clear_all_browsing_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-clear-all-browsing-data",
+          "markdownDescription": "Enables the clear_all_browsing_data command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-create-webview",
+          "markdownDescription": "Enables the create_webview command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-create-webview-window",
+          "markdownDescription": "Enables the create_webview_window command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_all_webviews command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-get-all-webviews",
+          "markdownDescription": "Enables the get_all_webviews command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-internal-toggle-devtools",
+          "markdownDescription": "Enables the internal_toggle_devtools command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the print command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-print",
+          "markdownDescription": "Enables the print command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the reparent command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-reparent",
+          "markdownDescription": "Enables the reparent command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_auto_resize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-auto-resize",
+          "markdownDescription": "Enables the set_webview_auto_resize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-background-color",
+          "markdownDescription": "Enables the set_webview_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-focus",
+          "markdownDescription": "Enables the set_webview_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-position",
+          "markdownDescription": "Enables the set_webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-size",
+          "markdownDescription": "Enables the set_webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-zoom",
+          "markdownDescription": "Enables the set_webview_zoom command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-close",
+          "markdownDescription": "Enables the webview_close command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-hide",
+          "markdownDescription": "Enables the webview_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-position",
+          "markdownDescription": "Enables the webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-show",
+          "markdownDescription": "Enables the webview_show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-size",
+          "markdownDescription": "Enables the webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the clear_all_browsing_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-clear-all-browsing-data",
+          "markdownDescription": "Denies the clear_all_browsing_data command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-create-webview",
+          "markdownDescription": "Denies the create_webview command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-create-webview-window",
+          "markdownDescription": "Denies the create_webview_window command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_all_webviews command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-get-all-webviews",
+          "markdownDescription": "Denies the get_all_webviews command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-internal-toggle-devtools",
+          "markdownDescription": "Denies the internal_toggle_devtools command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the print command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-print",
+          "markdownDescription": "Denies the print command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the reparent command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-reparent",
+          "markdownDescription": "Denies the reparent command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_auto_resize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-auto-resize",
+          "markdownDescription": "Denies the set_webview_auto_resize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-background-color",
+          "markdownDescription": "Denies the set_webview_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-focus",
+          "markdownDescription": "Denies the set_webview_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-position",
+          "markdownDescription": "Denies the set_webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-size",
+          "markdownDescription": "Denies the set_webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-zoom",
+          "markdownDescription": "Denies the set_webview_zoom command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-close",
+          "markdownDescription": "Denies the webview_close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-hide",
+          "markdownDescription": "Denies the webview_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-position",
+          "markdownDescription": "Denies the webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-show",
+          "markdownDescription": "Denies the webview_show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-size",
+          "markdownDescription": "Denies the webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`",
+          "type": "string",
+          "const": "core:window:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`"
+        },
+        {
+          "description": "Enables the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-available-monitors",
+          "markdownDescription": "Enables the available_monitors command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the center command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-center",
+          "markdownDescription": "Enables the center command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-close",
+          "markdownDescription": "Enables the close command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-create",
+          "markdownDescription": "Enables the create command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-current-monitor",
+          "markdownDescription": "Enables the current_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-cursor-position",
+          "markdownDescription": "Enables the cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the destroy command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-destroy",
+          "markdownDescription": "Enables the destroy command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_all_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-get-all-windows",
+          "markdownDescription": "Enables the get_all_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-hide",
+          "markdownDescription": "Enables the hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-inner-position",
+          "markdownDescription": "Enables the inner_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-inner-size",
+          "markdownDescription": "Enables the inner_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-internal-toggle-maximize",
+          "markdownDescription": "Enables the internal_toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-always-on-top",
+          "markdownDescription": "Enables the is_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-closable",
+          "markdownDescription": "Enables the is_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-decorated",
+          "markdownDescription": "Enables the is_decorated command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-enabled",
+          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-focused",
+          "markdownDescription": "Enables the is_focused command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-fullscreen",
+          "markdownDescription": "Enables the is_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-maximizable",
+          "markdownDescription": "Enables the is_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-maximized",
+          "markdownDescription": "Enables the is_maximized command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-minimizable",
+          "markdownDescription": "Enables the is_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-minimized",
+          "markdownDescription": "Enables the is_minimized command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-resizable",
+          "markdownDescription": "Enables the is_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-visible",
+          "markdownDescription": "Enables the is_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-maximize",
+          "markdownDescription": "Enables the maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the minimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-minimize",
+          "markdownDescription": "Enables the minimize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the monitor_from_point command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-monitor-from-point",
+          "markdownDescription": "Enables the monitor_from_point command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-outer-position",
+          "markdownDescription": "Enables the outer_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-outer-size",
+          "markdownDescription": "Enables the outer_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-primary-monitor",
+          "markdownDescription": "Enables the primary_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-request-user-attention",
+          "markdownDescription": "Enables the request_user_attention command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-scale-factor",
+          "markdownDescription": "Enables the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-always-on-bottom",
+          "markdownDescription": "Enables the set_always_on_bottom command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-always-on-top",
+          "markdownDescription": "Enables the set_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-background-color",
+          "markdownDescription": "Enables the set_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_badge_count command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-badge-count",
+          "markdownDescription": "Enables the set_badge_count command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_badge_label command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-badge-label",
+          "markdownDescription": "Enables the set_badge_label command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-closable",
+          "markdownDescription": "Enables the set_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-content-protected",
+          "markdownDescription": "Enables the set_content_protected command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-grab",
+          "markdownDescription": "Enables the set_cursor_grab command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-icon",
+          "markdownDescription": "Enables the set_cursor_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-position",
+          "markdownDescription": "Enables the set_cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-visible",
+          "markdownDescription": "Enables the set_cursor_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-decorations",
+          "markdownDescription": "Enables the set_decorations command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-effects",
+          "markdownDescription": "Enables the set_effects command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-enabled",
+          "markdownDescription": "Enables the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-focus",
+          "markdownDescription": "Enables the set_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_focusable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-focusable",
+          "markdownDescription": "Enables the set_focusable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-fullscreen",
+          "markdownDescription": "Enables the set_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-ignore-cursor-events",
+          "markdownDescription": "Enables the set_ignore_cursor_events command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-max-size",
+          "markdownDescription": "Enables the set_max_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-maximizable",
+          "markdownDescription": "Enables the set_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-min-size",
+          "markdownDescription": "Enables the set_min_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-minimizable",
+          "markdownDescription": "Enables the set_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_overlay_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-overlay-icon",
+          "markdownDescription": "Enables the set_overlay_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-position",
+          "markdownDescription": "Enables the set_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-progress-bar",
+          "markdownDescription": "Enables the set_progress_bar command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-resizable",
+          "markdownDescription": "Enables the set_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-shadow",
+          "markdownDescription": "Enables the set_shadow command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_simple_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-simple-fullscreen",
+          "markdownDescription": "Enables the set_simple_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-size",
+          "markdownDescription": "Enables the set_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_size_constraints command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-size-constraints",
+          "markdownDescription": "Enables the set_size_constraints command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-skip-taskbar",
+          "markdownDescription": "Enables the set_skip_taskbar command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-theme",
+          "markdownDescription": "Enables the set_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-title",
+          "markdownDescription": "Enables the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title_bar_style command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-title-bar-style",
+          "markdownDescription": "Enables the set_title_bar_style command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-visible-on-all-workspaces",
+          "markdownDescription": "Enables the set_visible_on_all_workspaces command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-show",
+          "markdownDescription": "Enables the show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-start-dragging",
+          "markdownDescription": "Enables the start_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-start-resize-dragging",
+          "markdownDescription": "Enables the start_resize_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-theme",
+          "markdownDescription": "Enables the theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-title",
+          "markdownDescription": "Enables the title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-toggle-maximize",
+          "markdownDescription": "Enables the toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-unmaximize",
+          "markdownDescription": "Enables the unmaximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-unminimize",
+          "markdownDescription": "Enables the unminimize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-available-monitors",
+          "markdownDescription": "Denies the available_monitors command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the center command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-center",
+          "markdownDescription": "Denies the center command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-close",
+          "markdownDescription": "Denies the close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-create",
+          "markdownDescription": "Denies the create command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-current-monitor",
+          "markdownDescription": "Denies the current_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-cursor-position",
+          "markdownDescription": "Denies the cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the destroy command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-destroy",
+          "markdownDescription": "Denies the destroy command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_all_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-get-all-windows",
+          "markdownDescription": "Denies the get_all_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-hide",
+          "markdownDescription": "Denies the hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-inner-position",
+          "markdownDescription": "Denies the inner_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-inner-size",
+          "markdownDescription": "Denies the inner_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-internal-toggle-maximize",
+          "markdownDescription": "Denies the internal_toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-always-on-top",
+          "markdownDescription": "Denies the is_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-closable",
+          "markdownDescription": "Denies the is_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-decorated",
+          "markdownDescription": "Denies the is_decorated command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-enabled",
+          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-focused",
+          "markdownDescription": "Denies the is_focused command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-fullscreen",
+          "markdownDescription": "Denies the is_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-maximizable",
+          "markdownDescription": "Denies the is_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-maximized",
+          "markdownDescription": "Denies the is_maximized command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-minimizable",
+          "markdownDescription": "Denies the is_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-minimized",
+          "markdownDescription": "Denies the is_minimized command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-resizable",
+          "markdownDescription": "Denies the is_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-visible",
+          "markdownDescription": "Denies the is_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-maximize",
+          "markdownDescription": "Denies the maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the minimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-minimize",
+          "markdownDescription": "Denies the minimize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the monitor_from_point command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-monitor-from-point",
+          "markdownDescription": "Denies the monitor_from_point command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-outer-position",
+          "markdownDescription": "Denies the outer_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-outer-size",
+          "markdownDescription": "Denies the outer_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-primary-monitor",
+          "markdownDescription": "Denies the primary_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-request-user-attention",
+          "markdownDescription": "Denies the request_user_attention command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-scale-factor",
+          "markdownDescription": "Denies the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-always-on-bottom",
+          "markdownDescription": "Denies the set_always_on_bottom command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-always-on-top",
+          "markdownDescription": "Denies the set_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-background-color",
+          "markdownDescription": "Denies the set_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_badge_count command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-badge-count",
+          "markdownDescription": "Denies the set_badge_count command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_badge_label command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-badge-label",
+          "markdownDescription": "Denies the set_badge_label command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-closable",
+          "markdownDescription": "Denies the set_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-content-protected",
+          "markdownDescription": "Denies the set_content_protected command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-grab",
+          "markdownDescription": "Denies the set_cursor_grab command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-icon",
+          "markdownDescription": "Denies the set_cursor_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-position",
+          "markdownDescription": "Denies the set_cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-visible",
+          "markdownDescription": "Denies the set_cursor_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-decorations",
+          "markdownDescription": "Denies the set_decorations command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-effects",
+          "markdownDescription": "Denies the set_effects command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-enabled",
+          "markdownDescription": "Denies the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-focus",
+          "markdownDescription": "Denies the set_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_focusable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-focusable",
+          "markdownDescription": "Denies the set_focusable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-fullscreen",
+          "markdownDescription": "Denies the set_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-ignore-cursor-events",
+          "markdownDescription": "Denies the set_ignore_cursor_events command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-max-size",
+          "markdownDescription": "Denies the set_max_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-maximizable",
+          "markdownDescription": "Denies the set_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-min-size",
+          "markdownDescription": "Denies the set_min_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-minimizable",
+          "markdownDescription": "Denies the set_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_overlay_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-overlay-icon",
+          "markdownDescription": "Denies the set_overlay_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-position",
+          "markdownDescription": "Denies the set_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-progress-bar",
+          "markdownDescription": "Denies the set_progress_bar command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-resizable",
+          "markdownDescription": "Denies the set_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-shadow",
+          "markdownDescription": "Denies the set_shadow command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_simple_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-simple-fullscreen",
+          "markdownDescription": "Denies the set_simple_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-size",
+          "markdownDescription": "Denies the set_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_size_constraints command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-size-constraints",
+          "markdownDescription": "Denies the set_size_constraints command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-skip-taskbar",
+          "markdownDescription": "Denies the set_skip_taskbar command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-theme",
+          "markdownDescription": "Denies the set_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-title",
+          "markdownDescription": "Denies the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title_bar_style command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-title-bar-style",
+          "markdownDescription": "Denies the set_title_bar_style command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-visible-on-all-workspaces",
+          "markdownDescription": "Denies the set_visible_on_all_workspaces command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-show",
+          "markdownDescription": "Denies the show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-start-dragging",
+          "markdownDescription": "Denies the start_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-start-resize-dragging",
+          "markdownDescription": "Denies the start_resize_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-theme",
+          "markdownDescription": "Denies the theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-title",
+          "markdownDescription": "Denies the title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-toggle-maximize",
+          "markdownDescription": "Denies the toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-unmaximize",
+          "markdownDescription": "Denies the unmaximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-unminimize",
+          "markdownDescription": "Denies the unminimize command without any pre-configured scope."
+        },
+        {
+          "description": "This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-download-and-install`",
+          "type": "string",
+          "const": "updater:default",
+          "markdownDescription": "This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-download-and-install`"
+        },
+        {
+          "description": "Enables the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-check",
+          "markdownDescription": "Enables the check command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download",
+          "markdownDescription": "Enables the download command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download-and-install",
+          "markdownDescription": "Enables the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-install",
+          "markdownDescription": "Enables the install command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-check",
+          "markdownDescription": "Denies the check command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download",
+          "markdownDescription": "Denies the download command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download-and-install",
+          "markdownDescription": "Denies the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-install",
+          "markdownDescription": "Denies the install command without any pre-configured scope."
+        }
+      ]
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+mod usd;
+
 use rfd::FileDialog;
 use serde::{Deserialize, Serialize};
 #[cfg(desktop)]
@@ -14,6 +16,10 @@ use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{Emitter, Manager};
 use tauri_plugin_updater::{Update, UpdaterExt};
 use url::Url;
+
+use crate::usd::{
+    AssetIssue, OpenusdBackend, StageInspection, StageSummary, UsdBackend, UsdError,
+};
 
 const SETTINGS_FILE_NAME: &str = "settings.json";
 const RECENT_FILES_FILE_NAME: &str = "recent-files.json";
@@ -89,6 +95,21 @@ struct UpdateInstallPayload {
 
 #[derive(Default)]
 struct PendingUpdateState(Mutex<Option<Update>>);
+
+/// Active USD inspection backend. Held as a trait object so the
+/// implementation can be swapped without touching command code.
+/// Currently `OpenusdBackend` (yohawing/openusd `yw-look-phase1`).
+struct UsdBackendState(Box<dyn UsdBackend>);
+
+impl UsdBackendState {
+    fn new(backend: impl UsdBackend + 'static) -> Self {
+        Self(Box::new(backend))
+    }
+
+    fn backend(&self) -> &dyn UsdBackend {
+        self.0.as_ref()
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1062,6 +1083,51 @@ fn load_diagnostics_snapshot(app: tauri::AppHandle) -> Result<DiagnosticsPayload
     })
 }
 
+fn map_usd_error(error: UsdError) -> String {
+    match error {
+        UsdError::NotImplemented => {
+            "USD inspection backend is not wired yet (Phase 1 in progress)".to_string()
+        }
+        other => other.to_string(),
+    }
+}
+
+#[tauri::command]
+fn inspect_stage(
+    backend: tauri::State<'_, UsdBackendState>,
+    path: String,
+) -> Result<StageInspection, String> {
+    let normalized = normalize_file_path(PathBuf::from(path))?;
+    backend
+        .backend()
+        .inspect_stage(&normalized)
+        .map_err(map_usd_error)
+}
+
+#[tauri::command]
+fn summarize_stage(
+    backend: tauri::State<'_, UsdBackendState>,
+    path: String,
+) -> Result<StageSummary, String> {
+    let normalized = normalize_file_path(PathBuf::from(path))?;
+    backend
+        .backend()
+        .summarize_stage(&normalized)
+        .map_err(map_usd_error)
+}
+
+#[tauri::command]
+fn collect_asset_issues(
+    backend: tauri::State<'_, UsdBackendState>,
+    path: String,
+) -> Result<Vec<AssetIssue>, String> {
+    let normalized = normalize_file_path(PathBuf::from(path))?;
+    backend
+        .backend()
+        .collect_asset_issues(&normalized)
+        .map_err(map_usd_error)
+}
+
 #[tauri::command]
 async fn check_for_update(
     app: tauri::AppHandle,
@@ -1161,6 +1227,7 @@ pub fn run() {
             }
 
             app.manage(PendingUpdateState::default());
+            app.manage(UsdBackendState::new(OpenusdBackend::new()));
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -1179,7 +1246,10 @@ pub fn run() {
             check_for_update,
             install_pending_update,
             inspect_asset,
-            load_format_support
+            load_format_support,
+            inspect_stage,
+            summarize_stage,
+            collect_asset_issues
         ])
         .run(tauri::generate_context!())
         .expect("error while running yw-look");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     fs::{self, OpenOptions},
     io::{Read as IoRead, Write},
     path::{Path, PathBuf},
-    sync::Mutex,
+    sync::{Arc, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
 #[cfg(desktop)]
@@ -96,18 +96,19 @@ struct UpdateInstallPayload {
 #[derive(Default)]
 struct PendingUpdateState(Mutex<Option<Update>>);
 
-/// Active USD inspection backend. Held as a trait object so the
-/// implementation can be swapped without touching command code.
+/// Active USD inspection backend. Held behind an `Arc` so each async
+/// Tauri command can clone a handle and move it into a blocking task
+/// without borrowing from `tauri::State`.
 /// Currently `OpenusdBackend` (yohawing/openusd `yw-look-phase1`).
-struct UsdBackendState(Box<dyn UsdBackend>);
+struct UsdBackendState(Arc<dyn UsdBackend>);
 
 impl UsdBackendState {
     fn new(backend: impl UsdBackend + 'static) -> Self {
-        Self(Box::new(backend))
+        Self(Arc::new(backend))
     }
 
-    fn backend(&self) -> &dyn UsdBackend {
-        self.0.as_ref()
+    fn handle(&self) -> Arc<dyn UsdBackend> {
+        Arc::clone(&self.0)
     }
 }
 
@@ -1084,48 +1085,48 @@ fn load_diagnostics_snapshot(app: tauri::AppHandle) -> Result<DiagnosticsPayload
 }
 
 fn map_usd_error(error: UsdError) -> String {
-    match error {
-        UsdError::NotImplemented => {
-            "USD inspection backend is not wired yet (Phase 1 in progress)".to_string()
-        }
-        other => other.to_string(),
-    }
+    error.to_string()
+}
+
+async fn run_blocking_usd<T, F>(task: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, UsdError> + Send + 'static,
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(task)
+        .await
+        .map_err(|e| format!("USD task join error: {e}"))?
+        .map_err(map_usd_error)
 }
 
 #[tauri::command]
-fn inspect_stage(
+async fn inspect_stage(
     backend: tauri::State<'_, UsdBackendState>,
     path: String,
 ) -> Result<StageInspection, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    backend
-        .backend()
-        .inspect_stage(&normalized)
-        .map_err(map_usd_error)
+    let handle = backend.handle();
+    run_blocking_usd(move || handle.inspect_stage(&normalized)).await
 }
 
 #[tauri::command]
-fn summarize_stage(
+async fn summarize_stage(
     backend: tauri::State<'_, UsdBackendState>,
     path: String,
 ) -> Result<StageSummary, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    backend
-        .backend()
-        .summarize_stage(&normalized)
-        .map_err(map_usd_error)
+    let handle = backend.handle();
+    run_blocking_usd(move || handle.summarize_stage(&normalized)).await
 }
 
 #[tauri::command]
-fn collect_asset_issues(
+async fn collect_asset_issues(
     backend: tauri::State<'_, UsdBackendState>,
     path: String,
 ) -> Result<Vec<AssetIssue>, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    backend
-        .backend()
-        .collect_asset_issues(&normalized)
-        .map_err(map_usd_error)
+    let handle = backend.handle();
+    run_blocking_usd(move || handle.collect_asset_issues(&normalized)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/usd/backend.rs
+++ b/src-tauri/src/usd/backend.rs
@@ -1,0 +1,71 @@
+//! USD backend abstraction.
+//!
+//! `yw-look` keeps the parser implementation behind this trait so the
+//! Tauri command layer never depends on a specific USD crate. The Phase 1
+//! implementation will plug in `OpenusdBackend` (a thin adapter over our
+//! fork of `mxpv/openusd`) once the fork API is stable.
+
+use std::path::Path;
+
+use super::types::{AssetIssue, StageInspection, StageSummary};
+
+/// Errors a USD backend can produce. Kept intentionally narrow so the
+/// command layer can map them to user-facing diagnostics consistently.
+#[derive(Debug)]
+pub enum UsdError {
+    /// The backend has not been wired yet (used by `StubBackend`).
+    NotImplemented,
+    /// The file could not be opened or read from disk.
+    Io(String),
+    /// The backend opened the file but failed to parse it.
+    Parse(String),
+}
+
+impl std::fmt::Display for UsdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UsdError::NotImplemented => write!(f, "USD backend is not implemented yet"),
+            UsdError::Io(message) => write!(f, "USD backend io error: {message}"),
+            UsdError::Parse(message) => write!(f, "USD backend parse error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for UsdError {}
+
+/// The single contract every USD parser implementation must satisfy.
+///
+/// Implementations are expected to be cheap to construct and safe to
+/// share across threads — Tauri's command runtime may invoke them from
+/// a worker pool.
+pub trait UsdBackend: Send + Sync {
+    /// Heavyweight inspection. May walk references / payloads.
+    fn inspect_stage(&self, path: &Path) -> Result<StageInspection, UsdError>;
+
+    /// Lightweight summary intended for the "show something instantly"
+    /// UX path. Implementations should avoid touching payloads.
+    fn summarize_stage(&self, path: &Path) -> Result<StageSummary, UsdError>;
+
+    /// Asset hygiene checks: broken references, suspicious metadata, etc.
+    fn collect_asset_issues(&self, path: &Path) -> Result<Vec<AssetIssue>, UsdError>;
+}
+
+/// Placeholder backend used while the fork of `mxpv/openusd` is in
+/// flight. Every method returns `NotImplemented` so the Tauri command
+/// surface can be wired and exercised end-to-end before the real parser
+/// arrives.
+pub struct StubBackend;
+
+impl UsdBackend for StubBackend {
+    fn inspect_stage(&self, _path: &Path) -> Result<StageInspection, UsdError> {
+        Err(UsdError::NotImplemented)
+    }
+
+    fn summarize_stage(&self, _path: &Path) -> Result<StageSummary, UsdError> {
+        Err(UsdError::NotImplemented)
+    }
+
+    fn collect_asset_issues(&self, _path: &Path) -> Result<Vec<AssetIssue>, UsdError> {
+        Err(UsdError::NotImplemented)
+    }
+}

--- a/src-tauri/src/usd/backend.rs
+++ b/src-tauri/src/usd/backend.rs
@@ -1,9 +1,9 @@
 //! USD backend abstraction.
 //!
 //! `yw-look` keeps the parser implementation behind this trait so the
-//! Tauri command layer never depends on a specific USD crate. The Phase 1
-//! implementation will plug in `OpenusdBackend` (a thin adapter over our
-//! fork of `mxpv/openusd`) once the fork API is stable.
+//! Tauri command layer never depends on a specific USD crate. The active
+//! implementation is `OpenusdBackend`, a thin adapter over our fork of
+//! `mxpv/openusd` (yohawing/openusd, branch `yw-look-phase1`).
 
 use std::path::Path;
 
@@ -13,8 +13,6 @@ use super::types::{AssetIssue, StageInspection, StageSummary};
 /// command layer can map them to user-facing diagnostics consistently.
 #[derive(Debug)]
 pub enum UsdError {
-    /// The backend has not been wired yet (used by `StubBackend`).
-    NotImplemented,
     /// The file could not be opened or read from disk.
     Io(String),
     /// The backend opened the file but failed to parse it.
@@ -24,7 +22,6 @@ pub enum UsdError {
 impl std::fmt::Display for UsdError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UsdError::NotImplemented => write!(f, "USD backend is not implemented yet"),
             UsdError::Io(message) => write!(f, "USD backend io error: {message}"),
             UsdError::Parse(message) => write!(f, "USD backend parse error: {message}"),
         }
@@ -48,24 +45,4 @@ pub trait UsdBackend: Send + Sync {
 
     /// Asset hygiene checks: broken references, suspicious metadata, etc.
     fn collect_asset_issues(&self, path: &Path) -> Result<Vec<AssetIssue>, UsdError>;
-}
-
-/// Placeholder backend used while the fork of `mxpv/openusd` is in
-/// flight. Every method returns `NotImplemented` so the Tauri command
-/// surface can be wired and exercised end-to-end before the real parser
-/// arrives.
-pub struct StubBackend;
-
-impl UsdBackend for StubBackend {
-    fn inspect_stage(&self, _path: &Path) -> Result<StageInspection, UsdError> {
-        Err(UsdError::NotImplemented)
-    }
-
-    fn summarize_stage(&self, _path: &Path) -> Result<StageSummary, UsdError> {
-        Err(UsdError::NotImplemented)
-    }
-
-    fn collect_asset_issues(&self, _path: &Path) -> Result<Vec<AssetIssue>, UsdError> {
-        Err(UsdError::NotImplemented)
-    }
 }

--- a/src-tauri/src/usd/mod.rs
+++ b/src-tauri/src/usd/mod.rs
@@ -1,0 +1,18 @@
+//! USD inspection module.
+//!
+//! Splits cleanly into:
+//!
+//! - [`types`] — wire-level types shared with the frontend.
+//! - [`backend`] — the [`backend::UsdBackend`] trait that every parser
+//!   implementation must satisfy, plus a [`backend::StubBackend`] used
+//!   while the real implementation is being prepared.
+
+pub mod backend;
+pub mod openusd_backend;
+pub mod types;
+
+pub use backend::{StubBackend, UsdBackend, UsdError};
+pub use openusd_backend::OpenusdBackend;
+pub use types::{
+    AssetIssue, AssetIssueCode, AssetIssueLevel, CompositionArc, StageInspection, StageSummary,
+};

--- a/src-tauri/src/usd/mod.rs
+++ b/src-tauri/src/usd/mod.rs
@@ -3,16 +3,15 @@
 //! Splits cleanly into:
 //!
 //! - [`types`] — wire-level types shared with the frontend.
-//! - [`backend`] — the [`backend::UsdBackend`] trait that every parser
-//!   implementation must satisfy, plus a [`backend::StubBackend`] used
-//!   while the real implementation is being prepared.
+//! - [`backend`] — the [`backend::UsdBackend`] trait every parser
+//!   implementation must satisfy.
+//! - [`openusd_backend`] — the concrete implementation used in the app,
+//!   a thin adapter over our fork of `mxpv/openusd`.
 
 pub mod backend;
 pub mod openusd_backend;
 pub mod types;
 
-pub use backend::{StubBackend, UsdBackend, UsdError};
+pub use backend::{UsdBackend, UsdError};
 pub use openusd_backend::OpenusdBackend;
-pub use types::{
-    AssetIssue, AssetIssueCode, AssetIssueLevel, CompositionArc, StageInspection, StageSummary,
-};
+pub use types::{AssetIssue, StageInspection, StageSummary};

--- a/src-tauri/src/usd/openusd_backend.rs
+++ b/src-tauri/src/usd/openusd_backend.rs
@@ -79,14 +79,14 @@ impl UsdBackend for OpenusdBackend {
                     references.borrow_mut().push(CompositionArc {
                         source_prim: source.clone(),
                         asset_path: r.asset_path,
-                        target_prim: Some(r.prim_path.to_string()),
+                        target_prim: r.prim_path.to_string(),
                     });
                 }
                 for p in stage.payloads_in(prim_path.clone()) {
                     payloads.borrow_mut().push(CompositionArc {
                         source_prim: source.clone(),
                         asset_path: p.asset_path,
-                        target_prim: Some(p.prim_path.to_string()),
+                        target_prim: p.prim_path.to_string(),
                     });
                 }
             })
@@ -165,17 +165,6 @@ impl UsdBackend for OpenusdBackend {
         let stage = Self::open(path)?;
         let mut issues = Vec::new();
 
-        // Axis / unit heuristic warnings — always unique, no duplication risk.
-        if let Some(UpAxis::Z) = stage.up_axis() {
-            issues.push(AssetIssue {
-                code: AssetIssueCode::ZUpAxis,
-                level: AssetIssueLevel::Warning,
-                message: "Stage uses Z-up axis; verify viewer orientation.".to_string(),
-                detail: None,
-                context_path: None,
-            });
-        }
-
         if let Some(mpu) = stage.meters_per_unit() {
             if mpu <= 0.0 || mpu > 100.0 {
                 issues.push(AssetIssue {
@@ -241,7 +230,7 @@ impl UsdBackend for OpenusdBackend {
         for missing in stage.unresolved_assets() {
             if !covered.contains(missing.as_str()) {
                 issues.push(AssetIssue {
-                    code: AssetIssueCode::BrokenReference,
+                    code: AssetIssueCode::MissingSubLayer,
                     level: AssetIssueLevel::Error,
                     message: format!("Unresolved asset: {missing}"),
                     detail: None,

--- a/src-tauri/src/usd/openusd_backend.rs
+++ b/src-tauri/src/usd/openusd_backend.rs
@@ -58,11 +58,11 @@ impl UsdBackend for OpenusdBackend {
             .root_prims()
             .map_err(|e| UsdError::Parse(e.to_string()))?;
 
-        // We expose every collected layer identifier as a "sub layer" for
-        // now. The fork does not yet distinguish authored sublayer specs
-        // from references / payloads in this accessor; the frontend treats
-        // this list as "all layers in the composed stage".
-        let sub_layers: Vec<String> = stage
+        // We expose every collected layer identifier (root layer excluded) as
+        // `composedLayers`. This includes all layers that participate in
+        // composition (references, payloads, sublayers) — not just authored
+        // `subLayers` arcs — which is what the frontend actually needs.
+        let composed_layers: Vec<String> = stage
             .layer_identifiers()
             .iter()
             .skip(1) // index 0 is the root layer itself
@@ -100,7 +100,7 @@ impl UsdBackend for OpenusdBackend {
             up_axis,
             meters_per_unit,
             root_prims,
-            sub_layers,
+            composed_layers,
             references: references.into_inner(),
             payloads: payloads.into_inner(),
             missing_assets,
@@ -165,16 +165,7 @@ impl UsdBackend for OpenusdBackend {
         let stage = Self::open(path)?;
         let mut issues = Vec::new();
 
-        for missing in stage.unresolved_assets() {
-            issues.push(AssetIssue {
-                code: AssetIssueCode::BrokenReference,
-                level: AssetIssueLevel::Error,
-                message: format!("Unresolved asset: {missing}"),
-                detail: None,
-                context_path: None,
-            });
-        }
-
+        // Axis / unit heuristic warnings — always unique, no duplication risk.
         if let Some(UpAxis::Z) = stage.up_axis() {
             issues.push(AssetIssue {
                 code: AssetIssueCode::ZUpAxis,
@@ -197,21 +188,27 @@ impl UsdBackend for OpenusdBackend {
             }
         }
 
-        // Walk references / payloads and flag any whose asset path is in
-        // the unresolved set so that the frontend can show *which* prim
-        // owns the broken arc.
+        // Build the set of unresolved assets for arc-level lookups.
         let unresolved: std::collections::HashSet<&str> = stage
             .unresolved_assets()
             .iter()
             .map(|s| s.as_str())
             .collect();
 
+        // Walk references / payloads and emit one contextualized issue per
+        // arc that points at an unresolved asset. Track which assets were
+        // attributed so that we can fall back to a generic issue for any
+        // that aren't reachable via an explicit arc.
         let collected: RefCell<Vec<AssetIssue>> = RefCell::new(Vec::new());
+        let covered: RefCell<std::collections::HashSet<String>> =
+            RefCell::new(std::collections::HashSet::new());
+
         stage
             .traverse(|prim_path| {
                 let source = prim_path.to_string();
                 for r in stage.references_in(prim_path.clone()) {
                     if unresolved.contains(r.asset_path.as_str()) {
+                        covered.borrow_mut().insert(r.asset_path.clone());
                         collected.borrow_mut().push(AssetIssue {
                             code: AssetIssueCode::BrokenReference,
                             level: AssetIssueLevel::Error,
@@ -223,6 +220,7 @@ impl UsdBackend for OpenusdBackend {
                 }
                 for p in stage.payloads_in(prim_path.clone()) {
                     if unresolved.contains(p.asset_path.as_str()) {
+                        covered.borrow_mut().insert(p.asset_path.clone());
                         collected.borrow_mut().push(AssetIssue {
                             code: AssetIssueCode::MissingPayload,
                             level: AssetIssueLevel::Error,
@@ -234,7 +232,23 @@ impl UsdBackend for OpenusdBackend {
                 }
             })
             .map_err(|e| UsdError::Parse(e.to_string()))?;
+
         issues.extend(collected.into_inner());
+
+        // Emit a generic (context-free) fallback only for unresolved assets
+        // that were not attributed to any specific arc during traversal.
+        let covered = covered.into_inner();
+        for missing in stage.unresolved_assets() {
+            if !covered.contains(missing.as_str()) {
+                issues.push(AssetIssue {
+                    code: AssetIssueCode::BrokenReference,
+                    level: AssetIssueLevel::Error,
+                    message: format!("Unresolved asset: {missing}"),
+                    detail: None,
+                    context_path: None,
+                });
+            }
+        }
 
         Ok(issues)
     }
@@ -250,11 +264,25 @@ mod tests {
         PathBuf::from("../samples/assets/usd/tiny.usda")
     }
 
+    /// Returns true when `path` contains only an LFS pointer (i.e. the
+    /// environment checked out without `lfs: true`). Tests call this and
+    /// return early so CI doesn't fail trying to parse a pointer file.
+    fn is_lfs_pointer(path: &PathBuf) -> bool {
+        std::fs::read_to_string(path)
+            .map(|s| s.starts_with("version https://git-lfs.github.com/spec/v1"))
+            .unwrap_or(false)
+    }
+
     #[test]
     fn summarize_tiny_usda() {
+        let path = tiny_usda();
+        if is_lfs_pointer(&path) {
+            eprintln!("SKIP summarize_tiny_usda: tiny.usda is an LFS pointer (checkout without lfs: true)");
+            return;
+        }
         let backend = OpenusdBackend::new();
         let summary = backend
-            .summarize_stage(&tiny_usda())
+            .summarize_stage(&path)
             .expect("summarize tiny.usda");
         assert_eq!(summary.layer_count, 1);
         assert_eq!(summary.root_prim_count, 1);
@@ -265,9 +293,14 @@ mod tests {
 
     #[test]
     fn inspect_tiny_usda() {
+        let path = tiny_usda();
+        if is_lfs_pointer(&path) {
+            eprintln!("SKIP inspect_tiny_usda: tiny.usda is an LFS pointer (checkout without lfs: true)");
+            return;
+        }
         let backend = OpenusdBackend::new();
         let inspection = backend
-            .inspect_stage(&tiny_usda())
+            .inspect_stage(&path)
             .expect("inspect tiny.usda");
         assert_eq!(inspection.default_prim.as_deref(), Some("Root"));
         assert_eq!(inspection.up_axis.as_deref(), Some("Y"));
@@ -280,9 +313,14 @@ mod tests {
 
     #[test]
     fn collect_issues_tiny_usda_is_clean() {
+        let path = tiny_usda();
+        if is_lfs_pointer(&path) {
+            eprintln!("SKIP collect_issues_tiny_usda_is_clean: tiny.usda is an LFS pointer (checkout without lfs: true)");
+            return;
+        }
         let backend = OpenusdBackend::new();
         let issues = backend
-            .collect_asset_issues(&tiny_usda())
+            .collect_asset_issues(&path)
             .expect("collect issues");
         // tiny.usda is Y-up, metersPerUnit=0.01, no missing assets → no issues
         assert!(issues.is_empty(), "expected no issues, got {issues:?}");

--- a/src-tauri/src/usd/openusd_backend.rs
+++ b/src-tauri/src/usd/openusd_backend.rs
@@ -1,0 +1,409 @@
+//! Concrete `UsdBackend` implementation backed by the `openusd` crate
+//! (yohawing fork of `mxpv/openusd`, branch `yw-look-phase1`).
+//!
+//! This adapter is intentionally thin: it converts paths, calls the
+//! parser, and maps the result into `yw-look`'s wire types in
+//! [`super::types`]. Anything richer (heuristics, scoring, UI sorting)
+//! belongs in the frontend or a higher layer.
+
+use std::cell::RefCell;
+use std::path::Path as StdPath;
+
+use openusd::ar::DefaultResolver;
+use openusd::sdf::schema::FieldKey;
+use openusd::sdf::Value as SdfValue;
+use openusd::stage::UpAxis;
+use openusd::Stage;
+
+use super::backend::{UsdBackend, UsdError};
+use super::types::{
+    AssetIssue, AssetIssueCode, AssetIssueLevel, CompositionArc, StageInspection, StageSummary,
+};
+
+/// Real backend backed by `openusd`.
+pub struct OpenusdBackend;
+
+impl OpenusdBackend {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn open(path: &StdPath) -> Result<Stage, UsdError> {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| UsdError::Io(format!("non-UTF8 path: {}", path.display())))?;
+        Stage::open(&DefaultResolver::new(), path_str)
+            .map_err(|e| UsdError::Parse(e.to_string()))
+    }
+}
+
+impl Default for OpenusdBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UsdBackend for OpenusdBackend {
+    fn inspect_stage(&self, path: &StdPath) -> Result<StageInspection, UsdError> {
+        let stage = Self::open(path)?;
+
+        let default_prim = stage.default_prim();
+        let up_axis = stage.up_axis().map(|axis| match axis {
+            UpAxis::Y => "Y".to_string(),
+            UpAxis::Z => "Z".to_string(),
+        });
+        let meters_per_unit = stage.meters_per_unit();
+
+        let root_prims = stage
+            .root_prims()
+            .map_err(|e| UsdError::Parse(e.to_string()))?;
+
+        // We expose every collected layer identifier as a "sub layer" for
+        // now. The fork does not yet distinguish authored sublayer specs
+        // from references / payloads in this accessor; the frontend treats
+        // this list as "all layers in the composed stage".
+        let sub_layers: Vec<String> = stage
+            .layer_identifiers()
+            .iter()
+            .skip(1) // index 0 is the root layer itself
+            .cloned()
+            .collect();
+
+        let references = RefCell::new(Vec::new());
+        let payloads = RefCell::new(Vec::new());
+
+        stage
+            .traverse(|prim_path| {
+                let source = prim_path.to_string();
+                for r in stage.references_in(prim_path.clone()) {
+                    references.borrow_mut().push(CompositionArc {
+                        source_prim: source.clone(),
+                        asset_path: r.asset_path,
+                        target_prim: Some(r.prim_path.to_string()),
+                    });
+                }
+                for p in stage.payloads_in(prim_path.clone()) {
+                    payloads.borrow_mut().push(CompositionArc {
+                        source_prim: source.clone(),
+                        asset_path: p.asset_path,
+                        target_prim: Some(p.prim_path.to_string()),
+                    });
+                }
+            })
+            .map_err(|e| UsdError::Parse(e.to_string()))?;
+
+        let missing_assets = stage.unresolved_assets().to_vec();
+
+        Ok(StageInspection {
+            path: path.display().to_string(),
+            default_prim,
+            up_axis,
+            meters_per_unit,
+            root_prims,
+            sub_layers,
+            references: references.into_inner(),
+            payloads: payloads.into_inner(),
+            missing_assets,
+        })
+    }
+
+    fn summarize_stage(&self, path: &StdPath) -> Result<StageSummary, UsdError> {
+        let stage = Self::open(path)?;
+
+        let layer_count = stage.layer_count();
+        let root_prim_count = stage
+            .root_prims()
+            .map_err(|e| UsdError::Parse(e.to_string()))?
+            .len();
+
+        let mesh_count = RefCell::new(0usize);
+        let payload_count = RefCell::new(0usize);
+        let has_variants = RefCell::new(false);
+
+        stage
+            .traverse(|prim_path| {
+                if let Ok(Some(type_name)) =
+                    stage.field::<String>(prim_path.clone(), FieldKey::TypeName)
+                {
+                    if type_name == "Mesh" {
+                        *mesh_count.borrow_mut() += 1;
+                    }
+                }
+                let payloads = stage.payloads_in(prim_path.clone());
+                if !payloads.is_empty() {
+                    *payload_count.borrow_mut() += payloads.len();
+                }
+                // VariantSetNames may be authored as several different
+                // value types depending on the layer; we only care that
+                // *something* is authored, so query as raw Value.
+                if let Ok(Some(_)) =
+                    stage.field::<SdfValue>(prim_path.clone(), FieldKey::VariantSetNames)
+                {
+                    *has_variants.borrow_mut() = true;
+                }
+            })
+            .map_err(|e| UsdError::Parse(e.to_string()))?;
+
+        let warnings: Vec<String> = stage
+            .unresolved_assets()
+            .iter()
+            .map(|a| format!("unresolved asset: {a}"))
+            .collect();
+
+        Ok(StageSummary {
+            path: path.display().to_string(),
+            layer_count,
+            root_prim_count,
+            mesh_count: mesh_count.into_inner(),
+            payload_count: payload_count.into_inner(),
+            has_variants: has_variants.into_inner(),
+            warnings,
+        })
+    }
+
+    fn collect_asset_issues(&self, path: &StdPath) -> Result<Vec<AssetIssue>, UsdError> {
+        let stage = Self::open(path)?;
+        let mut issues = Vec::new();
+
+        for missing in stage.unresolved_assets() {
+            issues.push(AssetIssue {
+                code: AssetIssueCode::BrokenReference,
+                level: AssetIssueLevel::Error,
+                message: format!("Unresolved asset: {missing}"),
+                detail: None,
+                context_path: None,
+            });
+        }
+
+        if let Some(UpAxis::Z) = stage.up_axis() {
+            issues.push(AssetIssue {
+                code: AssetIssueCode::ZUpAxis,
+                level: AssetIssueLevel::Warning,
+                message: "Stage uses Z-up axis; verify viewer orientation.".to_string(),
+                detail: None,
+                context_path: None,
+            });
+        }
+
+        if let Some(mpu) = stage.meters_per_unit() {
+            if mpu <= 0.0 || mpu > 100.0 {
+                issues.push(AssetIssue {
+                    code: AssetIssueCode::SuspiciousMetersPerUnit,
+                    level: AssetIssueLevel::Warning,
+                    message: format!("metersPerUnit = {mpu} is outside the typical range."),
+                    detail: None,
+                    context_path: None,
+                });
+            }
+        }
+
+        // Walk references / payloads and flag any whose asset path is in
+        // the unresolved set so that the frontend can show *which* prim
+        // owns the broken arc.
+        let unresolved: std::collections::HashSet<&str> = stage
+            .unresolved_assets()
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+
+        let collected: RefCell<Vec<AssetIssue>> = RefCell::new(Vec::new());
+        stage
+            .traverse(|prim_path| {
+                let source = prim_path.to_string();
+                for r in stage.references_in(prim_path.clone()) {
+                    if unresolved.contains(r.asset_path.as_str()) {
+                        collected.borrow_mut().push(AssetIssue {
+                            code: AssetIssueCode::BrokenReference,
+                            level: AssetIssueLevel::Error,
+                            message: format!("Broken reference: {}", r.asset_path),
+                            detail: None,
+                            context_path: Some(source.clone()),
+                        });
+                    }
+                }
+                for p in stage.payloads_in(prim_path.clone()) {
+                    if unresolved.contains(p.asset_path.as_str()) {
+                        collected.borrow_mut().push(AssetIssue {
+                            code: AssetIssueCode::MissingPayload,
+                            level: AssetIssueLevel::Error,
+                            message: format!("Missing payload: {}", p.asset_path),
+                            detail: None,
+                            context_path: Some(source.clone()),
+                        });
+                    }
+                }
+            })
+            .map_err(|e| UsdError::Parse(e.to_string()))?;
+        issues.extend(collected.into_inner());
+
+        Ok(issues)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tiny_usda() -> PathBuf {
+        // tests run with CWD = src-tauri
+        PathBuf::from("../samples/assets/usd/tiny.usda")
+    }
+
+    #[test]
+    fn summarize_tiny_usda() {
+        let backend = OpenusdBackend::new();
+        let summary = backend
+            .summarize_stage(&tiny_usda())
+            .expect("summarize tiny.usda");
+        assert_eq!(summary.layer_count, 1);
+        assert_eq!(summary.root_prim_count, 1);
+        assert_eq!(summary.mesh_count, 1, "tiny.usda has one Mesh");
+        assert_eq!(summary.payload_count, 0);
+        assert!(summary.warnings.is_empty());
+    }
+
+    #[test]
+    fn inspect_tiny_usda() {
+        let backend = OpenusdBackend::new();
+        let inspection = backend
+            .inspect_stage(&tiny_usda())
+            .expect("inspect tiny.usda");
+        assert_eq!(inspection.default_prim.as_deref(), Some("Root"));
+        assert_eq!(inspection.up_axis.as_deref(), Some("Y"));
+        assert_eq!(inspection.meters_per_unit, Some(0.01));
+        assert_eq!(inspection.root_prims, vec!["Root".to_string()]);
+        assert!(inspection.references.is_empty());
+        assert!(inspection.payloads.is_empty());
+        assert!(inspection.missing_assets.is_empty());
+    }
+
+    #[test]
+    fn collect_issues_tiny_usda_is_clean() {
+        let backend = OpenusdBackend::new();
+        let issues = backend
+            .collect_asset_issues(&tiny_usda())
+            .expect("collect issues");
+        // tiny.usda is Y-up, metersPerUnit=0.01, no missing assets → no issues
+        assert!(issues.is_empty(), "expected no issues, got {issues:?}");
+    }
+
+    // ----- Phase 0 production-asset parity tests --------------------------
+    //
+    // These tests reproduce the numbers we observed in `experiments/usd-poc`
+    // (see docs/usd-phase0.md) but through `OpenusdBackend` instead of the
+    // raw `openusd` API. They confirm the adapter does not lose information
+    // for real-world USD scenes.
+    //
+    // The assets live under `samples/private/` (license-restricted), so the
+    // tests are `#[ignore]`d by default and skipped automatically when the
+    // file is missing. Run them locally with:
+    //
+    //     cargo test --lib usd:: -- --ignored
+    //
+    // ---------------------------------------------------------------------
+
+    fn skip_if_missing(path: &PathBuf, name: &str) -> bool {
+        if !path.exists() {
+            eprintln!("SKIP {name}: not present at {}", path.display());
+            return true;
+        }
+        false
+    }
+
+    #[test]
+    #[ignore = "needs samples/private (Pixar license)"]
+    fn summarize_kitchen_set() {
+        let path = PathBuf::from(
+            "../samples/private/usd/Kitchen_set/Kitchen_set/Kitchen_set.usd",
+        );
+        if skip_if_missing(&path, "kitchen_set") {
+            return;
+        }
+        let backend = OpenusdBackend::new();
+        let summary = backend.summarize_stage(&path).expect("summarize kitchen_set");
+        // Phase 0 observation: 229 layers, 77 root prims, 2048 traversed prims.
+        assert_eq!(summary.layer_count, 229, "kitchen_set layer count");
+        assert_eq!(summary.root_prim_count, 77, "kitchen_set root prim count");
+    }
+
+    #[test]
+    #[ignore = "needs samples/private (Pixar license)"]
+    fn inspect_kitchen_set() {
+        let path = PathBuf::from(
+            "../samples/private/usd/Kitchen_set/Kitchen_set/Kitchen_set.usd",
+        );
+        if skip_if_missing(&path, "kitchen_set") {
+            return;
+        }
+        let backend = OpenusdBackend::new();
+        let inspection = backend.inspect_stage(&path).expect("inspect kitchen_set");
+        assert_eq!(inspection.default_prim.as_deref(), Some("Kitchen_set"));
+        assert_eq!(inspection.up_axis.as_deref(), Some("Z"));
+        // Phase 0 says references and payloads are heavily used.
+        assert!(
+            !inspection.references.is_empty(),
+            "kitchen_set should expose references"
+        );
+        assert!(
+            !inspection.payloads.is_empty(),
+            "kitchen_set should expose payloads"
+        );
+    }
+
+    #[test]
+    #[ignore = "needs samples/private (Pixar license) — depends on PR #41 fix"]
+    fn inspect_kitchen_set_instanced() {
+        // Phase 0 PoC: this file failed with `Unsupported prim metadata: instanceable`.
+        // The fork's `feature/instanceable-metadata` branch (upstream PR #41) is
+        // supposed to fix it. This test verifies the fix is wired into the
+        // git dependency.
+        let path = PathBuf::from(
+            "../samples/private/usd/Kitchen_set/Kitchen_set/Kitchen_set_instanced.usd",
+        );
+        if skip_if_missing(&path, "kitchen_set_instanced") {
+            return;
+        }
+        let backend = OpenusdBackend::new();
+        let inspection = backend
+            .inspect_stage(&path)
+            .expect("instanceable metadata regression: should now parse");
+        assert_eq!(inspection.default_prim.as_deref(), Some("Kitchen_set"));
+    }
+
+    #[test]
+    #[ignore = "needs samples/private (Apple AR Quick Look)"]
+    fn inspect_chameleon_usdz() {
+        let path = PathBuf::from(
+            "../samples/private/usd/chameleon_anim_mtl_variant.usdz",
+        );
+        if skip_if_missing(&path, "chameleon_usdz") {
+            return;
+        }
+        let backend = OpenusdBackend::new();
+        let summary = backend.summarize_stage(&path).expect("summarize chameleon");
+        assert_eq!(summary.layer_count, 1, "usdz reports as a single layer");
+        assert_eq!(summary.root_prim_count, 1);
+
+        let inspection = backend.inspect_stage(&path).expect("inspect chameleon");
+        assert_eq!(inspection.default_prim.as_deref(), Some("Root"));
+    }
+
+    #[test]
+    #[ignore = "needs samples/private (Apple AR Quick Look)"]
+    fn inspect_glove_usdz() {
+        let path = PathBuf::from(
+            "../samples/private/usd/glove_baseball_mtl_variant.usdz",
+        );
+        if skip_if_missing(&path, "glove_usdz") {
+            return;
+        }
+        let backend = OpenusdBackend::new();
+        let summary = backend.summarize_stage(&path).expect("summarize glove");
+        assert_eq!(summary.layer_count, 1);
+        assert_eq!(summary.root_prim_count, 1);
+
+        let inspection = backend.inspect_stage(&path).expect("inspect glove");
+        assert_eq!(inspection.default_prim.as_deref(), Some("glove_baseball"));
+    }
+}

--- a/src-tauri/src/usd/types.rs
+++ b/src-tauri/src/usd/types.rs
@@ -54,9 +54,6 @@ pub enum AssetIssueCode {
     MissingSubLayer,
     MissingPayload,
     SuspiciousMetersPerUnit,
-    ZUpAxis,
-    ParseFailure,
-    UnsupportedFeature,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -72,5 +69,5 @@ pub enum AssetIssueLevel {
 pub struct CompositionArc {
     pub source_prim: String,
     pub asset_path: String,
-    pub target_prim: Option<String>,
+    pub target_prim: String,
 }

--- a/src-tauri/src/usd/types.rs
+++ b/src-tauri/src/usd/types.rs
@@ -16,7 +16,7 @@ pub struct StageInspection {
     pub up_axis: Option<String>,
     pub meters_per_unit: Option<f64>,
     pub root_prims: Vec<String>,
-    pub sub_layers: Vec<String>,
+    pub composed_layers: Vec<String>,
     pub references: Vec<CompositionArc>,
     pub payloads: Vec<CompositionArc>,
     pub missing_assets: Vec<String>,

--- a/src-tauri/src/usd/types.rs
+++ b/src-tauri/src/usd/types.rs
@@ -1,0 +1,76 @@
+//! Wire-level types returned by USD inspection commands.
+//!
+//! These types live on the boundary between the Rust backend and the
+//! frontend, so they implement `Serialize`. They are intentionally
+//! independent of any specific USD parser crate so the frontend contract
+//! does not change when the backend implementation is swapped.
+
+use serde::Serialize;
+
+/// Heavyweight stage detail. Returned by `inspect_stage`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StageInspection {
+    pub path: String,
+    pub default_prim: Option<String>,
+    pub up_axis: Option<String>,
+    pub meters_per_unit: Option<f64>,
+    pub root_prims: Vec<String>,
+    pub sub_layers: Vec<String>,
+    pub references: Vec<CompositionArc>,
+    pub payloads: Vec<CompositionArc>,
+    pub missing_assets: Vec<String>,
+}
+
+/// Lightweight stage header. Returned by `summarize_stage` for the
+/// "show something instantly" UX path.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StageSummary {
+    pub path: String,
+    pub layer_count: usize,
+    pub root_prim_count: usize,
+    pub mesh_count: usize,
+    pub payload_count: usize,
+    pub has_variants: bool,
+    pub warnings: Vec<String>,
+}
+
+/// One issue surfaced by `collect_asset_issues`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetIssue {
+    pub code: AssetIssueCode,
+    pub level: AssetIssueLevel,
+    pub message: String,
+    pub detail: Option<String>,
+    pub context_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AssetIssueCode {
+    BrokenReference,
+    MissingSubLayer,
+    MissingPayload,
+    SuspiciousMetersPerUnit,
+    ZUpAxis,
+    ParseFailure,
+    UnsupportedFeature,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AssetIssueLevel {
+    Warning,
+    Error,
+}
+
+/// One composition arc (`reference` or `payload`) declared in a layer.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompositionArc {
+    pub source_prim: String,
+    pub asset_path: String,
+    pub target_prim: Option<String>,
+}

--- a/src/components/UsdInspectorCard.tsx
+++ b/src/components/UsdInspectorCard.tsx
@@ -61,8 +61,8 @@ export function UsdInspectorCard({
           )}
           {issues.length > 0 && (
             <ul className="card-list">
-              {issues.map((issue, idx) => (
-                <li key={idx} className={`issue issue-${issue.level}`}>
+              {issues.map((issue) => (
+                <li key={`${issue.code}:${issue.contextPath ?? ""}:${issue.message}`} className={`issue issue-${issue.level}`}>
                   <strong>{issue.code}</strong>: {issue.message}
                 </li>
               ))}

--- a/src/components/UsdInspectorCard.tsx
+++ b/src/components/UsdInspectorCard.tsx
@@ -1,0 +1,75 @@
+import type { AssetIssue, StageInspection, StageSummary } from "../lib/usd";
+
+type UsdInspectorCardProps = {
+  summary: StageSummary | null;
+  inspection: StageInspection | null;
+  issues: AssetIssue[];
+  loading: boolean;
+  error: string | null;
+};
+
+export function UsdInspectorCard({
+  summary,
+  inspection,
+  issues,
+  loading,
+  error,
+}: UsdInspectorCardProps) {
+  return (
+    <article className="card">
+      <p className="card-title">USD Inspector</p>
+      {error ? (
+        <p className="card-error">{error}</p>
+      ) : loading ? (
+        <p className="card-empty">Inspecting stage…</p>
+      ) : !summary && !inspection ? (
+        <p className="card-empty">
+          Open a USD/USDA/USDC/USDZ asset to inspect its stage.
+        </p>
+      ) : (
+        <>
+          {summary && (
+            <dl className="card-grid">
+              <dt>Layers</dt>
+              <dd>{summary.layerCount}</dd>
+              <dt>Root prims</dt>
+              <dd>{summary.rootPrimCount}</dd>
+              <dt>Meshes</dt>
+              <dd>{summary.meshCount}</dd>
+              <dt>Payloads</dt>
+              <dd>{summary.payloadCount}</dd>
+              <dt>Variants</dt>
+              <dd>{summary.hasVariants ? "yes" : "no"}</dd>
+            </dl>
+          )}
+          {inspection && (
+            <>
+              {inspection.defaultPrim && (
+                <p className="card-path">
+                  defaultPrim: {inspection.defaultPrim}
+                </p>
+              )}
+              {inspection.upAxis && (
+                <p className="card-path">upAxis: {inspection.upAxis}</p>
+              )}
+              {inspection.missingAssets.length > 0 && (
+                <p className="card-error">
+                  Missing assets: {inspection.missingAssets.length}
+                </p>
+              )}
+            </>
+          )}
+          {issues.length > 0 && (
+            <ul className="card-list">
+              {issues.map((issue, idx) => (
+                <li key={idx} className={`issue issue-${issue.level}`}>
+                  <strong>{issue.code}</strong>: {issue.message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </article>
+  );
+}

--- a/src/lib/usd.ts
+++ b/src/lib/usd.ts
@@ -12,7 +12,7 @@ export type StageInspection = {
   upAxis: string | null;
   metersPerUnit: number | null;
   rootPrims: string[];
-  subLayers: string[];
+  composedLayers: string[];
   references: CompositionArc[];
   payloads: CompositionArc[];
   missingAssets: string[];

--- a/src/lib/usd.ts
+++ b/src/lib/usd.ts
@@ -1,0 +1,60 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type CompositionArc = {
+  sourcePrim: string;
+  assetPath: string;
+  targetPrim: string | null;
+};
+
+export type StageInspection = {
+  path: string;
+  defaultPrim: string | null;
+  upAxis: string | null;
+  metersPerUnit: number | null;
+  rootPrims: string[];
+  subLayers: string[];
+  references: CompositionArc[];
+  payloads: CompositionArc[];
+  missingAssets: string[];
+};
+
+export type StageSummary = {
+  path: string;
+  layerCount: number;
+  rootPrimCount: number;
+  meshCount: number;
+  payloadCount: number;
+  hasVariants: boolean;
+  warnings: string[];
+};
+
+export type AssetIssueCode =
+  | "broken-reference"
+  | "missing-sub-layer"
+  | "missing-payload"
+  | "suspicious-meters-per-unit"
+  | "z-up-axis"
+  | "parse-failure"
+  | "unsupported-feature";
+
+export type AssetIssueLevel = "warning" | "error";
+
+export type AssetIssue = {
+  code: AssetIssueCode;
+  level: AssetIssueLevel;
+  message: string;
+  detail: string | null;
+  contextPath: string | null;
+};
+
+export async function inspectStage(path: string) {
+  return invoke<StageInspection>("inspect_stage", { path });
+}
+
+export async function summarizeStage(path: string) {
+  return invoke<StageSummary>("summarize_stage", { path });
+}
+
+export async function collectAssetIssues(path: string) {
+  return invoke<AssetIssue[]>("collect_asset_issues", { path });
+}

--- a/src/lib/usd.ts
+++ b/src/lib/usd.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 export type CompositionArc = {
   sourcePrim: string;
   assetPath: string;
-  targetPrim: string | null;
+  targetPrim: string;
 };
 
 export type StageInspection = {
@@ -32,10 +32,7 @@ export type AssetIssueCode =
   | "broken-reference"
   | "missing-sub-layer"
   | "missing-payload"
-  | "suspicious-meters-per-unit"
-  | "z-up-axis"
-  | "parse-failure"
-  | "unsupported-feature";
+  | "suspicious-meters-per-unit";
 
 export type AssetIssueLevel = "warning" | "error";
 

--- a/src/viewer/loaders.ts
+++ b/src/viewer/loaders.ts
@@ -1,9 +1,7 @@
 import {
   CompressedTexture,
   DataTexture,
-  Euler,
   Group,
-  Matrix4,
   Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
@@ -13,6 +11,7 @@ import {
   TextureLoader,
 } from "three";
 import { type SelectedFile, readBinaryFile } from "../lib/files";
+import { inspectStage } from "../lib/usd";
 import type {
   LoadedPreview,
   MissingReferenceError,
@@ -277,250 +276,11 @@ function applyObjTextureBundle(object: Group, bundle: TextureBundle) {
   });
 }
 
-type UsdXformHints = {
-  path: string;
-  hasMatrixTransform: boolean;
-  order: string[];
-  scale: [number, number, number] | null;
-  translate: [number, number, number] | null;
-  rotateXYZ: [number, number, number] | null;
-};
-
 type UsdRuntimeHints = {
   metersPerUnit: number | null;
-  xforms: UsdXformHints[];
 };
-
-const usdXformKeyPatterns = {
-  transform: /\bxformOp:transform(?!:)/,
-  scale: /\bxformOp:scale(?!:)/,
-  translate: /\bxformOp:translate(?!:)/,
-  rotateXYZ: /\bxformOp:rotateXYZ(?!:)/,
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function parseUsdFloatTuple(value: string): [number, number, number] | null {
-  const matches = value.match(/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/g);
-  if (!matches) {
-    return null;
-  }
-
-  const numbers = matches
-    .map((entry) => Number.parseFloat(entry))
-    .filter((num) => Number.isFinite(num));
-
-  if (numbers.length !== 3) {
-    return null;
-  }
-
-  return [numbers[0], numbers[1], numbers[2]];
-}
-
-function parseUsdOpOrder(value: string) {
-  const matches = value.match(/"([^"]+)"/g);
-  if (!matches) {
-    return [];
-  }
-
-  return matches.map((token) => token.replace(/^"|"$/g, ""));
-}
-
-function parseUsdNumericValue(value: string) {
-  const match = value.match(/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/);
-  if (!match) {
-    return null;
-  }
-
-  const numeric = Number.parseFloat(match[0]);
-  return Number.isFinite(numeric) ? numeric : null;
-}
-
-function findUsdMetersPerUnit(data: Record<string, unknown>): number | null {
-  for (const [key, value] of Object.entries(data)) {
-    if (typeof value === "string" && key.includes("metersPerUnit")) {
-      const parsed = parseUsdNumericValue(value);
-      if (parsed && parsed > 0) {
-        return parsed;
-      }
-    }
-
-    if (isRecord(value)) {
-      const nested = findUsdMetersPerUnit(value);
-      if (nested) {
-        return nested;
-      }
-    }
-  }
-
-  return null;
-}
-
-function extractUsdPrimName(key: string) {
-  const match = key.match(/^def Xform "([^"]+)"$/);
-  return match?.[1].trim() || null;
-}
-
-function buildUsdXformPath(parentSegments: string[], segment: string) {
-  return [...parentSegments, segment].join("/");
-}
-
-function isExactUsdXformKey(entryKey: string, op: string) {
-  const pattern = usdXformKeyPatterns[op as keyof typeof usdXformKeyPatterns];
-  return pattern ? pattern.test(entryKey) : false;
-}
-
-function collectUsdXformHints(
-  data: Record<string, unknown>,
-  parentSegments: string[],
-  result: UsdXformHints[],
-  siblingIndex = 0,
-): number {
-  let currentSiblingIndex = siblingIndex;
-
-  for (const [key, value] of Object.entries(data)) {
-    if (!isRecord(value)) {
-      continue;
-    }
-
-    if (key.startsWith("def Scope")) {
-      currentSiblingIndex = collectUsdXformHints(
-        value,
-        parentSegments,
-        result,
-        currentSiblingIndex,
-      );
-      continue;
-    }
-
-    if (key.startsWith("def Xform")) {
-      const segment = extractUsdPrimName(key) ?? `#${currentSiblingIndex}`;
-      const path = buildUsdXformPath(parentSegments, segment);
-      const hints: UsdXformHints = {
-        path,
-        hasMatrixTransform: false,
-        order: [],
-        scale: null,
-        translate: null,
-        rotateXYZ: null,
-      };
-
-      for (const [entryKey, entryValue] of Object.entries(value)) {
-        if (typeof entryValue !== "string") {
-          continue;
-        }
-
-        if (isExactUsdXformKey(entryKey, "transform")) {
-          hints.hasMatrixTransform = true;
-        } else if (isExactUsdXformKey(entryKey, "scale")) {
-          hints.scale = parseUsdFloatTuple(entryValue);
-        } else if (isExactUsdXformKey(entryKey, "translate")) {
-          hints.translate = parseUsdFloatTuple(entryValue);
-        } else if (isExactUsdXformKey(entryKey, "rotateXYZ")) {
-          hints.rotateXYZ = parseUsdFloatTuple(entryValue);
-        } else if (/\bxformOpOrder\b/.test(entryKey)) {
-          hints.order = parseUsdOpOrder(entryValue);
-        }
-      }
-
-      result.push(hints);
-      currentSiblingIndex += 1;
-      collectUsdXformHints(value, [...parentSegments, segment], result);
-    }
-  }
-
-  return currentSiblingIndex;
-}
-
-function collectUsdXformNodeMap(root: Object3D) {
-  const nodes = new Map<string, Object3D>();
-
-  const walk = (current: Object3D, parentSegments: string[]) => {
-    current.children.forEach((child, index) => {
-      const segment = child.name.trim() || `#${index}`;
-      const path = buildUsdXformPath(parentSegments, segment);
-      nodes.set(path, child);
-      walk(child, [...parentSegments, segment]);
-    });
-  };
-
-  walk(root, []);
-  return nodes;
-}
-
-function applyUsdXformHint(target: Object3D, hint: UsdXformHints) {
-  if (hint.hasMatrixTransform) {
-    return;
-  }
-
-  const order =
-    hint.order.length > 0
-      ? hint.order
-      : ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"];
-
-  const composed = new Matrix4().identity();
-  let transformed = false;
-
-  for (const rawToken of order) {
-    const invert = rawToken.startsWith("!invert!");
-    const token = rawToken.replace(/^!invert!/, "");
-    let step: Matrix4 | null = null;
-
-    if (token === "xformOp:translate" && hint.translate) {
-      step = new Matrix4().makeTranslation(
-        hint.translate[0],
-        hint.translate[1],
-        hint.translate[2],
-      );
-    } else if (token === "xformOp:rotateXYZ" && hint.rotateXYZ) {
-      step = new Matrix4().makeRotationFromEuler(
-        new Euler(
-          (hint.rotateXYZ[0] * Math.PI) / 180,
-          (hint.rotateXYZ[1] * Math.PI) / 180,
-          (hint.rotateXYZ[2] * Math.PI) / 180,
-          "XYZ",
-        ),
-      );
-    } else if (token === "xformOp:scale" && hint.scale) {
-      step = new Matrix4().makeScale(
-        hint.scale[0],
-        hint.scale[1],
-        hint.scale[2],
-      );
-    }
-
-    if (!step) {
-      continue;
-    }
-
-    if (invert) {
-      step.invert();
-    }
-
-    composed.multiply(step);
-    transformed = true;
-  }
-
-  if (!transformed) {
-    return;
-  }
-
-  composed.decompose(target.position, target.quaternion, target.scale);
-}
 
 function applyUsdRuntimeHints(object: Object3D, hints: UsdRuntimeHints) {
-  const nodeMap = collectUsdXformNodeMap(object);
-
-  for (const hint of hints.xforms) {
-    const target = nodeMap.get(hint.path);
-    if (!target) {
-      continue;
-    }
-    applyUsdXformHint(target, hint);
-  }
-
   if (!hints.metersPerUnit || Math.abs(hints.metersPerUnit - 1) < 1e-6) {
     return;
   }
@@ -635,23 +395,38 @@ function readUsdzFirstFileName(buffer: ArrayBuffer) {
 }
 
 async function parseUsdRuntimeHints(
-  usdaText: string,
+  path: string,
 ): Promise<UsdRuntimeHints> {
-  const parserModulePath = "three/examples/jsm/loaders/usd/USDAParser.js";
-  const parserModule = (await import(parserModulePath)) as {
-    USDAParser: new () => {
-      parseText: (text: string) => Record<string, unknown>;
-    };
-  };
-  const { USDAParser } = parserModule;
-  const parser = new USDAParser();
-  const root = parser.parseText(usdaText) as Record<string, unknown>;
-  const xforms: UsdXformHints[] = [];
-  collectUsdXformHints(root, [], xforms);
-
+  // Delegated to the Rust `OpenusdBackend` via the Tauri command surface,
+  // so this works for USDA, USDC, and USDZ uniformly. Returns just the
+  // pieces the Three.js viewer cannot recover by itself — currently only
+  // `metersPerUnit` (USDLoader handles the xform graph natively).
+  //
+  // Wrapped in a hard timeout so a hung / slow backend call can never
+  // stall the preview pipeline — we fall back to "no hint" and the
+  // viewer still renders with USDLoader's own scene.
+  const started = performance.now();
+  const TIMEOUT_MS = 10_000;
+  const inspection = await Promise.race([
+    inspectStage(path),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              `inspectStage timeout after ${TIMEOUT_MS}ms for ${path}`,
+            ),
+          ),
+        TIMEOUT_MS,
+      ),
+    ),
+  ]);
+  const elapsed = Math.round(performance.now() - started);
+  console.info(
+    `[usd] inspectStage OK in ${elapsed}ms: metersPerUnit=${inspection.metersPerUnit}`,
+  );
   return {
-    metersPerUnit: findUsdMetersPerUnit(root),
-    xforms,
+    metersPerUnit: inspection.metersPerUnit,
   };
 }
 
@@ -760,13 +535,11 @@ export async function loadPreviewObject(
       const usdaText = await tryExtractUsdaText(file.extension, buffer);
       const object = usdaText ? loader.parse(usdaText) : loader.parse(buffer);
 
-      if (usdaText) {
-        try {
-          const runtimeHints = await parseUsdRuntimeHints(usdaText);
-          applyUsdRuntimeHints(object, runtimeHints);
-        } catch (error) {
-          console.warn("USD hint parsing failed:", error);
-        }
+      try {
+        const runtimeHints = await parseUsdRuntimeHints(file.path);
+        applyUsdRuntimeHints(object, runtimeHints);
+      } catch (error) {
+        console.warn("USD hint parsing failed:", error);
       }
 
       return {


### PR DESCRIPTION
Five reviewer issues on the Phase 1 USD inspection backend PR, ranging from correctness (duplicate issues emitted by `collect_asset_issues`) to CI reliability (tests fail in environments without LFS) and API clarity (`subLayers` was a misnomer).

## Changes

- **LFS guard in tests** — Added `is_lfs_pointer()` helper; the three default `#[test]` cases skip early when `tiny.usda` is a pointer file, fixing `cargo test` in CI checkouts without `lfs: true`.

- **Rename `sub_layers` → `composed_layers`** — `StageInspection` wire type (Rust struct + TS mirror) now uses `composedLayers`. The old name implied authored `subLayers` arcs only; the actual value is all layers participating in composition.

- **Pin `openusd` git dep to a `rev`** — Dropped the floating `branch` reference from `Cargo.toml`; pinned to `d924cac` so the source-of-truth is in the manifest, not only the lockfile.

- **Stable React key in `UsdInspectorCard`** — Replaced array-index key with `` `${issue.code}:${issue.contextPath ?? ""}:${issue.message}` `` to avoid incorrect DOM reuse on list mutations.

- **De-duplicate `collect_asset_issues`** — The original code emitted a context-free `BrokenReference` for every entry in `unresolved_assets()` *and* a contextualized issue for the same asset during traversal. Now only contextualized arc-level issues are emitted; a generic fallback fires only for unresolved assets not attributable to any specific reference or payload arc.

```rust
// Before: duplicates guaranteed — global pass + per-arc pass for same asset
for missing in stage.unresolved_assets() { issues.push(BrokenReference …) }
// … then traverse also pushes BrokenReference / MissingPayload for same paths

// After: single pass; fallback only for assets unreachable via any arc
stage.traverse(|prim_path| {
    for r in stage.references_in(prim_path.clone()) {
        if unresolved.contains(r.asset_path.as_str()) {
            covered.insert(r.asset_path.clone());
            collected.push(BrokenReference { context_path: Some(source) … });
        }
    }
    // same pattern for payloads → MissingPayload
});
for missing in stage.unresolved_assets() {
    if !covered.contains(missing) { issues.push(generic fallback) }
}
```