### PR TITLE
ui: apply reviewer feedback on environment preset controls

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -114,7 +114,7 @@
 - [ ] プリセットビューを実装する（Front / Back / Left / Right / Top / Bottom）
 - [ ] バックフェースカリング ON/OFF を実装する
 - [ ] 環境マップ背景表示 ON/OFF を実装する（HDRI 背景 or 灰色）
-- [ ] 環境マップのプリセット切替を実装する（Studio / Outdoor / Neutral 等）
+- [x] 環境マップのプリセット切替を実装する（Studio / Outdoor / Neutral 等）
 - [ ] ボーン / スケルトン表示を実装する（アニメーション付きモデル用）
 - [ ] 軸ギズモ（XYZ インジケーター）を表示する
 - [ ] トーンマッピング切替を実装する（Linear / ACES / Reinhard）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   AssetViewport,
   type DisplayMode,
+  type EnvironmentPreset,
   type TextureViewMode,
   type ViewerFeedback,
   type ViewerSurfaceMode,
@@ -105,6 +106,15 @@ function deriveDisplayMode(
   return "untextured";
 }
 
+const environmentPresets: Array<{
+  id: EnvironmentPreset;
+  label: string;
+}> = [
+  { id: "studio", label: "Studio" },
+  { id: "neutral", label: "Neutral" },
+  { id: "outdoor", label: "Outdoor" },
+];
+
 const DiagnosticsCard = lazy(() =>
   import("./components/DiagnosticsCard").then((module) => ({
     default: module.DiagnosticsCard,
@@ -146,6 +156,8 @@ export function App() {
   const [showTexture, setShowTexture] = useState(true);
   const [showWireframe, setShowWireframe] = useState(false);
   const [showGrid, setShowGrid] = useState(true);
+  const [environmentPreset, setEnvironmentPreset] =
+    useState<EnvironmentPreset>("studio");
   const [gridUnitLabel, setGridUnitLabel] = useState("1 m");
   const [currentFile, setCurrentFile] = useState<SelectedFile | null>(null);
   const [directoryListing, setDirectoryListing] =
@@ -1220,6 +1232,7 @@ export function App() {
             resetVersion={resetVersion}
             showGrid={showGrid}
             onGridUnitChange={setGridUnitLabel}
+            environmentPreset={environmentPreset}
           />
 
           {/* ViewModeControls overlay */}
@@ -1250,6 +1263,21 @@ export function App() {
               <span>Grid</span>
               <span className={`toggle-switch${showGrid ? " is-on" : ""}`} />
             </button>
+            <div className="view-mode-section">
+              <span className="view-mode-section-label">Environment</span>
+              <div className="preset-chip-row">
+                {environmentPresets.map((preset) => (
+                  <button
+                    key={preset.id}
+                    className={`preset-chip${environmentPreset === preset.id ? " is-active" : ""}`}
+                    onClick={() => setEnvironmentPreset(preset.id)}
+                    type="button"
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
 
           {/* InfoPanel toggle button */}

--- a/src/components/AssetViewport.tsx
+++ b/src/components/AssetViewport.tsx
@@ -3,18 +3,23 @@ import {
   ACESFilmicToneMapping,
   AmbientLight,
   AnimationMixer,
+  BackSide,
+  BoxGeometry,
   Color,
   DirectionalLight,
+  Mesh,
+  MeshBasicMaterial,
   MOUSE,
   PerspectiveCamera,
   PMREMGenerator,
   Scene,
+  SphereGeometry,
   Texture,
   Vector2,
+  WebGLRenderTarget,
   WebGLRenderer,
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
-import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
 import type { SelectedFile } from "../lib/files";
 import {
   type DisplayMode,
@@ -53,6 +58,7 @@ import { emptyAnimationState, type AnimationState } from "./animation";
 import { ViewerStatePanel } from "./ViewerStatePanel";
 
 export type { ViewerFeedback, DisplayMode, ViewerSurfaceMode, TextureViewMode };
+export type EnvironmentPreset = "studio" | "neutral" | "outdoor";
 
 type AssetViewportProps = {
   currentFile: SelectedFile | null;
@@ -68,7 +74,163 @@ type AssetViewportProps = {
   resetVersion: number;
   showGrid: boolean;
   onGridUnitChange: (label: string) => void;
+  environmentPreset: EnvironmentPreset;
 };
+
+function disposeEnvironmentScene(scene: Scene) {
+  scene.traverse((child) => {
+    if (!(child instanceof Mesh)) {
+      return;
+    }
+
+    child.geometry.dispose();
+
+    if (Array.isArray(child.material)) {
+      for (const material of child.material) {
+        material.dispose();
+      }
+      return;
+    }
+
+    child.material.dispose();
+  });
+}
+
+function buildEnvironmentScene(preset: EnvironmentPreset) {
+  const scene = new Scene();
+  const shell = new Mesh(
+    new SphereGeometry(40, 40, 20),
+    new MeshBasicMaterial({ color: "#121418", side: BackSide }),
+  );
+  scene.add(shell);
+
+  const addPanel = ({
+    color,
+    position,
+    scale,
+    rotation = [0, 0, 0],
+  }: {
+    color: string;
+    position: [number, number, number];
+    scale: [number, number, number];
+    rotation?: [number, number, number];
+  }) => {
+    const panel = new Mesh(
+      new BoxGeometry(scale[0], scale[1], scale[2]),
+      new MeshBasicMaterial({ color }),
+    );
+    panel.position.set(position[0], position[1], position[2]);
+    panel.rotation.set(rotation[0], rotation[1], rotation[2]);
+    scene.add(panel);
+  };
+
+  const addGlowSphere = ({
+    color,
+    position,
+    radius,
+  }: {
+    color: string;
+    position: [number, number, number];
+    radius: number;
+  }) => {
+    const glow = new Mesh(
+      new SphereGeometry(radius, 24, 16),
+      new MeshBasicMaterial({ color }),
+    );
+    glow.position.set(position[0], position[1], position[2]);
+    scene.add(glow);
+  };
+
+  switch (preset) {
+    case "neutral":
+      shell.material.color.set("#191c21");
+      addPanel({
+        color: "#f3f4f8",
+        position: [0, 9, -18],
+        scale: [14, 14, 0.45],
+      });
+      addPanel({
+        color: "#dde3ee",
+        position: [-15, 5, -8],
+        scale: [9, 12, 0.4],
+        rotation: [0, 0.32, 0],
+      });
+      addPanel({
+        color: "#d7dde7",
+        position: [15, 4, -7],
+        scale: [9, 11, 0.4],
+        rotation: [0, -0.34, 0],
+      });
+      addPanel({
+        color: "#747c88",
+        position: [0, -10, 0],
+        scale: [32, 0.5, 32],
+      });
+      break;
+    case "outdoor":
+      shell.material.color.set("#1a2432");
+      addGlowSphere({
+        color: "#ffe6b3",
+        position: [0, 11, -16],
+        radius: 3.6,
+      });
+      addPanel({
+        color: "#7fb3ff",
+        position: [-16, 5, -8],
+        scale: [12, 10, 0.4],
+        rotation: [0, 0.42, 0],
+      });
+      addPanel({
+        color: "#d7ecff",
+        position: [14, 7, -9],
+        scale: [8, 12, 0.35],
+        rotation: [0, -0.26, 0],
+      });
+      addPanel({
+        color: "#4a5665",
+        position: [0, -11, 0],
+        scale: [36, 0.5, 36],
+      });
+      break;
+    case "studio":
+    default:
+      addPanel({
+        color: "#ffffff",
+        position: [0, 8, -16],
+        scale: [12, 12, 0.45],
+      });
+      addPanel({
+        color: "#bfd0ff",
+        position: [-15, 5, -9],
+        scale: [8, 14, 0.4],
+        rotation: [0, 0.38, 0],
+      });
+      addPanel({
+        color: "#ffe2c2",
+        position: [15, 4, -8],
+        scale: [8, 10, 0.4],
+        rotation: [0, -0.34, 0],
+      });
+      addPanel({
+        color: "#626977",
+        position: [0, -10, 0],
+        scale: [34, 0.5, 34],
+      });
+      break;
+  }
+
+  return scene;
+}
+
+function createEnvironmentTarget(
+  pmremGenerator: PMREMGenerator,
+  preset: EnvironmentPreset,
+) {
+  const environmentScene = buildEnvironmentScene(preset);
+  const target = pmremGenerator.fromScene(environmentScene, 0.04);
+  disposeEnvironmentScene(environmentScene);
+  return target;
+}
 
 export function AssetViewport({
   currentFile,
@@ -84,10 +246,15 @@ export function AssetViewport({
   resetVersion,
   showGrid,
   onGridUnitChange,
+  environmentPreset,
 }: AssetViewportProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const sceneContextRef = useRef<SceneContext | null>(null);
   const resetCameraRef = useRef<(() => void) | null>(null);
+  const environmentTargetRef = useRef<WebGLRenderTarget | null>(null);
+  const activeEnvironmentPresetRef = useRef<EnvironmentPreset>(
+    environmentPreset,
+  );
   const displayModeRef = useRef(displayMode);
   const showGridRef = useRef(showGrid);
   const [activePreviewPath, setActivePreviewPath] = useState<string | null>(
@@ -152,10 +319,11 @@ export function AssetViewport({
     camera.up.set(0, 1, 0);
 
     const pmremGenerator = new PMREMGenerator(renderer);
-    scene.environment = pmremGenerator.fromScene(
-      new RoomEnvironment(),
-      0.04,
-    ).texture;
+    environmentTargetRef.current = createEnvironmentTarget(
+      pmremGenerator,
+      activeEnvironmentPresetRef.current,
+    );
+    scene.environment = environmentTargetRef.current.texture;
 
     const ambient = new AmbientLight("#ffffff", 1.8);
     const key = new DirectionalLight("#ffffff", 2.4);
@@ -251,6 +419,8 @@ export function AssetViewport({
       }
       revokeUrls(sceneContextRef.current?.cleanupUrls ?? []);
       controls.dispose();
+      environmentTargetRef.current?.dispose();
+      environmentTargetRef.current = null;
       pmremGenerator.dispose();
       renderer.dispose();
       host.removeChild(renderer.domElement);
@@ -263,6 +433,26 @@ export function AssetViewport({
     onMetadataChange,
     shouldInitializeScene,
   ]);
+
+  useEffect(() => {
+    const context = sceneContextRef.current;
+
+    if (!context) {
+      return;
+    }
+
+    if (activeEnvironmentPresetRef.current === environmentPreset) {
+      return;
+    }
+
+    environmentTargetRef.current?.dispose();
+    environmentTargetRef.current = createEnvironmentTarget(
+      context.pmremGenerator,
+      environmentPreset,
+    );
+    activeEnvironmentPresetRef.current = environmentPreset;
+    context.scene.environment = environmentTargetRef.current.texture;
+  }, [environmentPreset]);
 
   useEffect(() => {
     const context = sceneContextRef.current;

--- a/src/components/AssetViewport.tsx
+++ b/src/components/AssetViewport.tsx
@@ -107,16 +107,16 @@ function buildEnvironmentScene(preset: EnvironmentPreset) {
   const addPanel = ({
     color,
     position,
-    scale,
+    size,
     rotation = [0, 0, 0],
   }: {
     color: string;
     position: [number, number, number];
-    scale: [number, number, number];
+    size: [number, number, number];
     rotation?: [number, number, number];
   }) => {
     const panel = new Mesh(
-      new BoxGeometry(scale[0], scale[1], scale[2]),
+      new BoxGeometry(size[0], size[1], size[2]),
       new MeshBasicMaterial({ color }),
     );
     panel.position.set(position[0], position[1], position[2]);
@@ -147,24 +147,24 @@ function buildEnvironmentScene(preset: EnvironmentPreset) {
       addPanel({
         color: "#f3f4f8",
         position: [0, 9, -18],
-        scale: [14, 14, 0.45],
+        size: [14, 14, 0.45],
       });
       addPanel({
         color: "#dde3ee",
         position: [-15, 5, -8],
-        scale: [9, 12, 0.4],
+        size: [9, 12, 0.4],
         rotation: [0, 0.32, 0],
       });
       addPanel({
         color: "#d7dde7",
         position: [15, 4, -7],
-        scale: [9, 11, 0.4],
+        size: [9, 11, 0.4],
         rotation: [0, -0.34, 0],
       });
       addPanel({
         color: "#747c88",
         position: [0, -10, 0],
-        scale: [32, 0.5, 32],
+        size: [32, 0.5, 32],
       });
       break;
     case "outdoor":
@@ -177,19 +177,19 @@ function buildEnvironmentScene(preset: EnvironmentPreset) {
       addPanel({
         color: "#7fb3ff",
         position: [-16, 5, -8],
-        scale: [12, 10, 0.4],
+        size: [12, 10, 0.4],
         rotation: [0, 0.42, 0],
       });
       addPanel({
         color: "#d7ecff",
         position: [14, 7, -9],
-        scale: [8, 12, 0.35],
+        size: [8, 12, 0.35],
         rotation: [0, -0.26, 0],
       });
       addPanel({
         color: "#4a5665",
         position: [0, -11, 0],
-        scale: [36, 0.5, 36],
+        size: [36, 0.5, 36],
       });
       break;
     case "studio":
@@ -197,24 +197,24 @@ function buildEnvironmentScene(preset: EnvironmentPreset) {
       addPanel({
         color: "#ffffff",
         position: [0, 8, -16],
-        scale: [12, 12, 0.45],
+        size: [12, 12, 0.45],
       });
       addPanel({
         color: "#bfd0ff",
         position: [-15, 5, -9],
-        scale: [8, 14, 0.4],
+        size: [8, 14, 0.4],
         rotation: [0, 0.38, 0],
       });
       addPanel({
         color: "#ffe2c2",
         position: [15, 4, -8],
-        scale: [8, 10, 0.4],
+        size: [8, 10, 0.4],
         rotation: [0, -0.34, 0],
       });
       addPanel({
         color: "#626977",
         position: [0, -10, 0],
-        scale: [34, 0.5, 34],
+        size: [34, 0.5, 34],
       });
       break;
   }
@@ -252,6 +252,7 @@ export function AssetViewport({
   const sceneContextRef = useRef<SceneContext | null>(null);
   const resetCameraRef = useRef<(() => void) | null>(null);
   const environmentTargetRef = useRef<WebGLRenderTarget | null>(null);
+  const environmentTargetsRef = useRef<Map<EnvironmentPreset, WebGLRenderTarget>>(new Map());
   const activeEnvironmentPresetRef = useRef<EnvironmentPreset>(
     environmentPreset,
   );
@@ -321,8 +322,10 @@ export function AssetViewport({
     const pmremGenerator = new PMREMGenerator(renderer);
     environmentTargetRef.current = createEnvironmentTarget(
       pmremGenerator,
-      activeEnvironmentPresetRef.current,
+      environmentPreset,
     );
+    environmentTargetsRef.current.set(environmentPreset, environmentTargetRef.current);
+    activeEnvironmentPresetRef.current = environmentPreset;
     scene.environment = environmentTargetRef.current.texture;
 
     const ambient = new AmbientLight("#ffffff", 1.8);
@@ -419,7 +422,8 @@ export function AssetViewport({
       }
       revokeUrls(sceneContextRef.current?.cleanupUrls ?? []);
       controls.dispose();
-      environmentTargetRef.current?.dispose();
+      environmentTargetsRef.current.forEach((target) => target.dispose());
+      environmentTargetsRef.current.clear();
       environmentTargetRef.current = null;
       pmremGenerator.dispose();
       renderer.dispose();
@@ -445,13 +449,19 @@ export function AssetViewport({
       return;
     }
 
-    environmentTargetRef.current?.dispose();
-    environmentTargetRef.current = createEnvironmentTarget(
-      context.pmremGenerator,
-      environmentPreset,
-    );
+    let nextTarget = environmentTargetsRef.current.get(environmentPreset);
+
+    if (!nextTarget) {
+      nextTarget = createEnvironmentTarget(
+        context.pmremGenerator,
+        environmentPreset,
+      );
+      environmentTargetsRef.current.set(environmentPreset, nextTarget);
+    }
+
+    environmentTargetRef.current = nextTarget;
     activeEnvironmentPresetRef.current = environmentPreset;
-    context.scene.environment = environmentTargetRef.current.texture;
+    context.scene.environment = nextTarget.texture;
   }, [environmentPreset]);
 
   useEffect(() => {

--- a/src/components/AssetViewport.tsx
+++ b/src/components/AssetViewport.tsx
@@ -252,7 +252,7 @@ export function AssetViewport({
   const sceneContextRef = useRef<SceneContext | null>(null);
   const resetCameraRef = useRef<(() => void) | null>(null);
   const environmentTargetRef = useRef<WebGLRenderTarget | null>(null);
-  const environmentTargetsRef = useRef<Map<EnvironmentPreset, WebGLRenderTarget>>(new Map());
+  const environmentTargetsRef = useRef<Map<EnvironmentPreset, WebGLRenderTarget> | null>(null);
   const activeEnvironmentPresetRef = useRef<EnvironmentPreset>(
     environmentPreset,
   );
@@ -320,11 +320,14 @@ export function AssetViewport({
     camera.up.set(0, 1, 0);
 
     const pmremGenerator = new PMREMGenerator(renderer);
+    environmentTargetsRef.current = new Map();
     environmentTargetRef.current = createEnvironmentTarget(
       pmremGenerator,
       environmentPreset,
     );
-    environmentTargetsRef.current.set(environmentPreset, environmentTargetRef.current);
+    if (environmentTargetRef.current) {
+      environmentTargetsRef.current.set(environmentPreset, environmentTargetRef.current);
+    }
     activeEnvironmentPresetRef.current = environmentPreset;
     scene.environment = environmentTargetRef.current.texture;
 
@@ -422,8 +425,9 @@ export function AssetViewport({
       }
       revokeUrls(sceneContextRef.current?.cleanupUrls ?? []);
       controls.dispose();
-      environmentTargetsRef.current.forEach((target) => target.dispose());
-      environmentTargetsRef.current.clear();
+      environmentTargetsRef.current?.forEach((target) => target.dispose());
+      environmentTargetsRef.current?.clear();
+      environmentTargetsRef.current = null;
       environmentTargetRef.current = null;
       pmremGenerator.dispose();
       renderer.dispose();
@@ -449,14 +453,16 @@ export function AssetViewport({
       return;
     }
 
-    let nextTarget = environmentTargetsRef.current.get(environmentPreset);
+    let nextTarget = environmentTargetsRef.current?.get(environmentPreset);
 
     if (!nextTarget) {
       nextTarget = createEnvironmentTarget(
         context.pmremGenerator,
         environmentPreset,
       );
-      environmentTargetsRef.current.set(environmentPreset, nextTarget);
+      if (environmentTargetsRef.current) {
+        environmentTargetsRef.current.set(environmentPreset, nextTarget);
+      }
     }
 
     environmentTargetRef.current = nextTarget;

--- a/src/styles.css
+++ b/src/styles.css
@@ -412,7 +412,18 @@ textarea {
   font-size: 11px;
   font-weight: 510;
   line-height: 1.4;
-  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    color 0.15s,
+    box-shadow 0.15s;
+}
+
+.preset-chip:focus-visible {
+  outline: 2px solid rgba(113, 112, 255, 0.9);
+  outline-offset: 2px;
+  border-color: rgba(113, 112, 255, 0.56);
+  box-shadow: 0 0 0 3px rgba(113, 112, 255, 0.18);
 }
 
 .preset-chip:hover {

--- a/src/styles.css
+++ b/src/styles.css
@@ -380,6 +380,53 @@ textarea {
   background: rgba(255, 255, 255, 0.05);
 }
 
+.view-mode-section {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding-top: 4px;
+}
+
+.view-mode-section-label {
+  color: #8a8f98;
+  font-size: 10px;
+  font-weight: 510;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0 4px;
+}
+
+.preset-chip-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.preset-chip {
+  min-width: 0;
+  padding: 7px 10px;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: #d0d6e0;
+  font-size: 11px;
+  font-weight: 510;
+  line-height: 1.4;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.preset-chip:hover {
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f7f8f8;
+}
+
+.preset-chip.is-active {
+  border-color: rgba(113, 112, 255, 0.56);
+  background: rgba(113, 112, 255, 0.14);
+  color: #f7f8f8;
+}
+
 .toggle-switch {
   width: 32px;
   height: 16px;


### PR DESCRIPTION
Four issues raised in review on PR #17 (environment map presets):

## Changes

- **`:focus-visible` on `.preset-chip`** — adds keyboard focus ring (outline + box-shadow) using existing accent color tokens; `box-shadow` added to `transition` list.

- **`scale` → `size` in `addPanel`** — the parameter name implied transform scale; renamed to `size` across parameter declaration, type annotation, `BoxGeometry` usage, and all 12 call-sites.

- **Fix stale ref at scene init** — initial PMREM target was created from `activeEnvironmentPresetRef.current` (which could be stale if `environmentPreset` changed before the renderer mounted). Now uses the `environmentPreset` prop directly and seeds `activeEnvironmentPresetRef` at init time.

- **Cache PMREM targets per preset** — previously disposed and regenerated the `WebGLRenderTarget` on every preset switch. Replaced with `Map<EnvironmentPreset, WebGLRenderTarget> | null` ref (`environmentTargetsRef`), lazily initialized in the scene-setup effect, reused on repeat switches, disposed in full on unmount.

```ts
// Before: dispose + regenerate every switch
environmentTargetRef.current?.dispose();
environmentTargetRef.current = createEnvironmentTarget(context.pmremGenerator, environmentPreset);

// After: generate once per preset, reuse thereafter
let nextTarget = environmentTargetsRef.current?.get(environmentPreset);
if (!nextTarget) {
  nextTarget = createEnvironmentTarget(context.pmremGenerator, environmentPreset);
  environmentTargetsRef.current?.set(environmentPreset, nextTarget);
}
```