### PR TITLE
fix(usd): fail fast on USDC binary in three.js preview path

### DIFF
--- a/src/viewer/loaders.ts
+++ b/src/viewer/loaders.ts
@@ -552,6 +552,19 @@ export async function loadPreviewObject(
       const buffer = await readArrayBuffer(file.path);
       const loader = new USDLoader();
       const usdaText = await tryExtractUsdaText(file.extension, buffer);
+
+      // Three.js USDLoader only handles USDA (ASCII) format. When
+      // tryExtractUsdaText returns null for a non-USDZ file it means the
+      // buffer is USDC binary crate format, which the loader cannot parse.
+      // Passing raw USDC to USDLoader silently produces empty geometry, so
+      // we fail fast here with a clear message instead.
+      if (usdaText === null && file.extension !== "usdz") {
+        throw new Error(
+          `USDC binary format (${file.fileName}) cannot be rendered by the Three.js preview. ` +
+            `Stage metadata and inspection are still available in the sidebar.`,
+        );
+      }
+
       // Phase 2: yield one frame so the USD inspector sidebar (which is
       // populated in parallel by App.tsx via the Rust backend) has a chance
       // to paint before we block the main thread on the synchronous
@@ -583,15 +596,22 @@ export async function loadPreviewObject(
       // the worker output to `Group` to match `LoadedPreview.object` —
       // the scene graph shape is compatible even if the runtime class
       // nominal identity differs.
-      const object: Group =
-        (workerObject as Group | null) ??
-        (usdaText ? loader.parse(usdaText) : loader.parse(buffer));
+      let object: Group;
+      try {
+        object =
+          (workerObject as Group | null) ??
+          (usdaText ? loader.parse(usdaText) : loader.parse(buffer));
+        console.info(`[usd] USDLoader.parse OK: ${file.fileName}`);
+      } catch (parseError) {
+        console.error("[usd] USDLoader.parse failed:", parseError);
+        throw parseError;
+      }
 
       try {
         const runtimeHints = await parseUsdRuntimeHints(file.path);
         applyUsdRuntimeHints(object, runtimeHints);
       } catch (error) {
-        console.warn("USD hint parsing failed:", error);
+        console.warn("[usd] runtime hints failed:", error);
       }
 
       return {


### PR DESCRIPTION
## Summary
- USDLoader (three.js) は USDA (ASCII) しか扱えないため、USDC バイナリを渡すと `loader.parse` が静かに空ジオメトリを返してしまう。`tryExtractUsdaText` が `null` を返した非 USDZ ファイルは USDC とみなして明示的に throw し、UI 側でエラー表示できるようにする。
- USD inspector サイドバーは Rust バックエンド経由でステージメタデータを別ルートで取得しているので、throw 後もメタデータ閲覧は引き続き利用可能。
- `USDLoader.parse` 周りに success / error の console ログを追加し、runtime-hints の失敗ログのプレフィクスも `[usd]` に揃えた。

## Background
`feat/usd-phase2` 開発中に、USDC ファイルを開くとビューポートが空のまま操作不能になる挙動を確認。原因が USDLoader の silent failure だったため fail-fast に切り替える。

## Test plan
- [x] `npx tsc --noEmit` pass (ローカル確認済)
- [ ] USDA ファイル (`samples/assets/usd/tiny.usda` 等) を開いてプレビューが従来通り表示されること
- [ ] USDC ファイルを開いてビューポートにエラーが表示され、サイドバーのステージメタデータは正常に表示されること
- [ ] USDZ ファイルを開いて従来どおり表示されること (USDZ は throw 経路に入らない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)