### PR TITLE
chore: format AssetViewport.tsx with prettier

### DIFF
--- a/src/components/AssetViewport.tsx
+++ b/src/components/AssetViewport.tsx
@@ -252,10 +252,12 @@ export function AssetViewport({
   const sceneContextRef = useRef<SceneContext | null>(null);
   const resetCameraRef = useRef<(() => void) | null>(null);
   const environmentTargetRef = useRef<WebGLRenderTarget | null>(null);
-  const environmentTargetsRef = useRef<Map<EnvironmentPreset, WebGLRenderTarget> | null>(null);
-  const activeEnvironmentPresetRef = useRef<EnvironmentPreset>(
-    environmentPreset,
-  );
+  const environmentTargetsRef = useRef<Map<
+    EnvironmentPreset,
+    WebGLRenderTarget
+  > | null>(null);
+  const activeEnvironmentPresetRef =
+    useRef<EnvironmentPreset>(environmentPreset);
   const displayModeRef = useRef(displayMode);
   const showGridRef = useRef(showGrid);
   const [activePreviewPath, setActivePreviewPath] = useState<string | null>(
@@ -326,7 +328,10 @@ export function AssetViewport({
       environmentPreset,
     );
     if (environmentTargetRef.current) {
-      environmentTargetsRef.current.set(environmentPreset, environmentTargetRef.current);
+      environmentTargetsRef.current.set(
+        environmentPreset,
+        environmentTargetRef.current,
+      );
     }
     activeEnvironmentPresetRef.current = environmentPreset;
     scene.environment = environmentTargetRef.current.texture;


### PR DESCRIPTION
## Summary
Mechanical \`prettier --write\` fix for two ref declarations in \`src/components/AssetViewport.tsx\`. The file drifted out of prettier compliance on develop (likely from a previous PR that was merged without running format:check), and \`format:check\` was failing on every PR targeting develop as a result.

This unblocks PRs #18 and #19 once merged.

## Test plan
- [x] \`npx prettier --check src/components/AssetViewport.tsx\` passes locally
- [ ] CI \`frontend-checks\` (Format check) passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)