### PR TITLE
fix(loader): fail-closed JS fallback for composition-bearing USD (#59)

### DIFF
--- a/src/viewer/__tests__/loaders.test.ts
+++ b/src/viewer/__tests__/loaders.test.ts
@@ -13,6 +13,7 @@ import {
   resolveSiblingPath,
   isUsdcCrateBuffer,
   readUsdzFirstFileName,
+  shouldFailClosedOnUsdPreviewDecisionFailure,
 } from "../loaders";
 
 // ---------------------------------------------------------------------------
@@ -150,6 +151,33 @@ describe("isUsdcCrateBuffer", () => {
 
   it("returns false for an empty buffer", () => {
     expect(isUsdcCrateBuffer(new ArrayBuffer(0))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldFailClosedOnUsdPreviewDecisionFailure
+// ---------------------------------------------------------------------------
+
+describe("shouldFailClosedOnUsdPreviewDecisionFailure", () => {
+  it.each(["usd", "usda", "usdz"])(
+    "fails closed for %s in the Tauri runtime",
+    (extension) => {
+      expect(shouldFailClosedOnUsdPreviewDecisionFailure(extension, true)).toBe(
+        true,
+      );
+    },
+  );
+
+  it("keeps the JS fallback available for browser selftests", () => {
+    expect(shouldFailClosedOnUsdPreviewDecisionFailure("usda", false)).toBe(
+      false,
+    );
+  });
+
+  it("does not change the existing USDC fail-fast path", () => {
+    expect(shouldFailClosedOnUsdPreviewDecisionFailure("usdc", true)).toBe(
+      false,
+    );
   });
 });
 

--- a/src/viewer/loaders.ts
+++ b/src/viewer/loaders.ts
@@ -11,6 +11,7 @@ import {
   TextureLoader,
 } from "three";
 import { type SelectedFile, readBinaryFile } from "../lib/files";
+import { isTauriEnvironment } from "../lib/platform";
 import { extractGeometry, inspectStage, requiresGlbPreview } from "../lib/usd";
 import { isUsdWorkerEnabled, parseUsdInWorker } from "./usdWorkerLoader";
 import type {
@@ -335,6 +336,16 @@ function isUsdcCrateBuffer(buffer: ArrayBuffer) {
   return crateHeader.every((value, index) => view[index] === value);
 }
 
+function shouldFailClosedOnUsdPreviewDecisionFailure(
+  extension: string,
+  isTauriRuntime: boolean,
+) {
+  return (
+    isTauriRuntime &&
+    (extension === "usd" || extension === "usda" || extension === "usdz")
+  );
+}
+
 export async function tryExtractUsdaText(
   extension: string,
   buffer: ArrayBuffer,
@@ -465,6 +476,7 @@ export {
   resolveSiblingPath,
   isUsdcCrateBuffer,
   readUsdzFirstFileName,
+  shouldFailClosedOnUsdPreviewDecisionFailure,
 };
 
 export async function loadPreviewObject(
@@ -693,9 +705,23 @@ export async function loadPreviewObject(
         reportStage("resolve");
         useGlbPipeline = await requiresGlbPreview(file.path);
       } catch (error) {
+        if (
+          shouldFailClosedOnUsdPreviewDecisionFailure(
+            file.extension,
+            isTauriEnvironment(),
+          )
+        ) {
+          throw new Error(
+            `Unable to determine whether ${file.fileName} requires the USD composition backend. ` +
+              `JS fallback is disabled for .${file.extension} files because references, payloads, or sublayers could be omitted from the preview.`,
+            { cause: error },
+          );
+        }
+
         // If the Rust check itself fails (e.g. a catastrophic parse
-        // error) fall through to the JS-side magic-byte sniff so the
-        // load can still proceed and the user sees at least *something*.
+        // error) outside the Tauri app, fall through to the JS-side
+        // magic-byte sniff so browser selftests and mocked environments
+        // can still exercise the offline preview path.
         console.warn(
           "[usd] requires_glb_preview failed, falling back to JS detection:",
           error,


### PR DESCRIPTION
Closes #59

## Summary
- backend (`requiresGlbPreview`) 判定が失敗した時に `.usd/.usda/.usdz` で JS detection fallback に落ちず、明示エラーで fail-closed する
- composition (references / payloads / sublayers) を含み得るファイル形式で参照欠落の preview を出すリスクを排除

## Changes
- src/viewer/loaders.ts
  - `shouldFailClosedOnUsdPreviewDecisionFailure(extension, isTauriRuntime)` helper 追加
  - Tauri runtime かつ `.usd/.usda/.usdz` の時は明示 Error を throw
  - 非 Tauri (browser selftest / モック) では従来 fallback を維持
- src/viewer/__tests__/loaders.test.ts
  - 上記 helper の判定テスト追加

## Verification
- pnpm typecheck: pass
- pnpm tsc --noEmit: pass
- pnpm lint: pass (既存 warning 2 件のみ)
- pnpm exec prettier --check: pass
- pnpm test: 環境制約 (esbuild EPERM) で未実行。ロジックは型 + lint で確認済み

## Self-Review (Codex)
信頼度: 中
- 実装スコープは loaders.ts と関連 test のみで Issue 仕様通り
- `.usdc` は既存 USDC fail-fast 経路を維持
- selftest fallback も明確に区別されている
- 残課題: Vitest を実環境で再実行