### PR TITLE
perf(usd): release registry map lock during stage operations (#56)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1811,13 +1811,12 @@ async fn load_payload(
     // the async runtime stays responsive to other IPC traffic.
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let registry = app.state::<StageRegistry>();
-        registry
-            .with(handle, |session| {
-                backend_handle
-                    .load_payload(&session.stage, &prim_path)
-                    .map_err(|e| e.to_string())
-            })
-            .ok_or_else(|| format!("load_payload: unknown session handle {}", handle.0))?
+        let session = registry
+            .get(handle)
+            .ok_or_else(|| format!("load_payload: unknown session handle {}", handle.0))?;
+        backend_handle
+            .load_payload(&session.stage, &prim_path)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| format!("USD task join error: {e}"))?
@@ -1842,13 +1841,12 @@ async fn unload_payload(
     // and to guarantee the registry mutex isn't held across `.await`.
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let registry = app.state::<StageRegistry>();
-        registry
-            .with(handle, |session| {
-                backend_handle
-                    .unload_payload(&session.stage, &prim_path)
-                    .map_err(|e| e.to_string())
-            })
-            .ok_or_else(|| format!("unload_payload: unknown session handle {}", handle.0))?
+        let session = registry
+            .get(handle)
+            .ok_or_else(|| format!("unload_payload: unknown session handle {}", handle.0))?;
+        backend_handle
+            .unload_payload(&session.stage, &prim_path)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| format!("USD task join error: {e}"))?
@@ -1876,22 +1874,21 @@ async fn extract_geometry_session(
     // (avoids holding a `tauri::State` reference across `.await`).
     let bytes = tauri::async_runtime::spawn_blocking(move || -> Result<Vec<u8>, String> {
         let registry = app.state::<StageRegistry>();
-        registry
-            .with(handle, |session| {
-                backend_handle
-                    .extract_geometry_from_session(
-                        &session.stage,
-                        &session.path,
-                        &resolved_options,
-                    )
-                    .map_err(|e| e.to_string())
-            })
+        let session = registry
+            .get(handle)
             .ok_or_else(|| {
                 format!(
                     "extract_geometry_session: unknown session handle {}",
                     handle.0
                 )
-            })?
+            })?;
+        backend_handle
+            .extract_geometry_from_session(
+                &session.stage,
+                &session.path,
+                &resolved_options,
+            )
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| format!("USD task join error: {e}"))??;

--- a/src-tauri/src/usd/stage_state.rs
+++ b/src-tauri/src/usd/stage_state.rs
@@ -10,14 +10,16 @@
 //! Thread-safety note: `StageRegistry` wraps each `OpenStage` variant in a
 //! `Mutex` so the registry itself is `Send + Sync` — required by Tauri's
 //! `app.manage()`. The `CStage` handle is explicitly NOT `Sync` (only
-//! `Send`), so we keep it behind a per-session `Mutex<CStage>` and never
-//! hand out a reference that crosses a `.await` boundary.
+//! `Send`), so we keep it behind a per-session `Mutex<CStage>`. The
+//! registry map stores sessions behind `Arc` handles so lookup only holds
+//! the map lock long enough to clone the session pointer; heavyweight stage
+//! operations contend only on the individual session's stage mutex.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
-    Mutex,
+    Arc, Mutex,
 };
 
 use super::types::StageLoadPolicy;
@@ -67,7 +69,7 @@ pub struct OpenSession {
 /// Tauri command as `tauri::State<'_, StageRegistry>`.
 pub struct StageRegistry {
     next: AtomicU64,
-    sessions: Mutex<HashMap<u64, OpenSession>>,
+    sessions: Mutex<HashMap<u64, Arc<OpenSession>>>,
 }
 
 impl StageRegistry {
@@ -83,15 +85,22 @@ impl StageRegistry {
     pub fn insert(&self, session: OpenSession) -> StageSessionHandle {
         let id = self.next.fetch_add(1, Ordering::Relaxed);
         let mut map = self.sessions.lock().expect("StageRegistry lock poisoned");
-        map.insert(id, session);
+        map.insert(id, Arc::new(session));
         StageSessionHandle(id)
     }
 
-    /// Removes and returns the session for `handle`, or `None` if it
-    /// does not exist.
-    pub fn remove(&self, handle: StageSessionHandle) -> Option<OpenSession> {
+    /// Removes and returns the session handle for `handle`, or `None` if it
+    /// does not exist. In-flight operations that already cloned the `Arc`
+    /// keep the session alive until they finish; future lookups fail.
+    pub fn remove(&self, handle: StageSessionHandle) -> Option<Arc<OpenSession>> {
         let mut map = self.sessions.lock().expect("StageRegistry lock poisoned");
         map.remove(&handle.0)
+    }
+
+    /// Returns a cloned session handle for `handle`.
+    pub fn get(&self, handle: StageSessionHandle) -> Option<Arc<OpenSession>> {
+        let map = self.sessions.lock().expect("StageRegistry lock poisoned");
+        map.get(&handle.0).cloned()
     }
 
     /// Calls `f` with a shared reference to the session for `handle`.
@@ -100,18 +109,7 @@ impl StageRegistry {
     where
         F: FnOnce(&OpenSession) -> R,
     {
-        let map = self.sessions.lock().expect("StageRegistry lock poisoned");
-        map.get(&handle.0).map(f)
-    }
-
-    /// Calls `f` with a mutable reference to the session for `handle`.
-    /// Returns `None` when the handle is unknown.
-    pub fn with_mut<F, R>(&self, handle: StageSessionHandle, f: F) -> Option<R>
-    where
-        F: FnOnce(&mut OpenSession) -> R,
-    {
-        let mut map = self.sessions.lock().expect("StageRegistry lock poisoned");
-        map.get_mut(&handle.0).map(f)
+        self.get(handle).map(|session| f(&session))
     }
 
     /// Returns the number of open sessions.
@@ -127,5 +125,62 @@ impl StageRegistry {
 impl Default for StageRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, feature = "backend-openusd-rs"))]
+mod tests {
+    use super::*;
+    use crate::usd::{OpenusdBackend, UsdBackend};
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    fn tiny_usda_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("samples")
+            .join("assets")
+            .join("usd")
+            .join("tiny.usda")
+    }
+
+    fn open_test_session(backend: &OpenusdBackend) -> OpenSession {
+        let path = tiny_usda_path();
+        let policy = StageLoadPolicy::default();
+        let stage = backend
+            .open_stage_session(&path, policy)
+            .expect("open tiny.usda test session");
+        OpenSession {
+            path,
+            policy,
+            stage,
+        }
+    }
+
+    #[test]
+    fn with_does_not_hold_registry_lock_while_running_closure() {
+        let backend = OpenusdBackend::new();
+        let registry = Arc::new(StageRegistry::new());
+        let active = registry.insert(open_test_session(&backend));
+        let removable = registry.insert(open_test_session(&backend));
+
+        registry
+            .with(active, |_| {
+                let (tx, rx) = mpsc::channel();
+                let registry = Arc::clone(&registry);
+                std::thread::spawn(move || {
+                    let removed = registry.remove(removable).is_some();
+                    tx.send(removed).expect("send remove result");
+                });
+
+                assert_eq!(
+                    rx.recv_timeout(Duration::from_secs(1)),
+                    Ok(true),
+                    "registry map lock stayed held while with() closure was running"
+                );
+            })
+            .expect("active session exists");
+
+        assert_eq!(registry.len(), 1);
     }
 }


### PR DESCRIPTION
Closes #56

## Summary
- `StageRegistry` を `Mutex<HashMap<u64, Arc<OpenSession>>>` に変更し、registry map lock は `Arc` clone までの短時間だけ保持
- 重い USD 操作 (`load_payload` / `unload_payload` / `extract_geometry_session`) を session の `Arc` を使って実行し、registry 全体をブロックしない
- 1 session の GLB 抽出中でも別 session の close / load / unload が進めるようになる

## Changes
- src-tauri/src/usd/stage_state.rs
  - `sessions: Mutex<HashMap<u64, Arc<OpenSession>>>`
  - `get(handle) -> Option<Arc<OpenSession>>` を追加
  - `with()` は `Arc` clone 後に closure を呼ぶ形へ
  - `remove()` は `Arc<OpenSession>` を返す (in-flight 操作は Arc lifetime で完走可能)
  - regression test (Rust backend feature 限定) を追加: with() 実行中に別 session を remove() できることを 1 秒タイムアウトで確認
- src-tauri/src/lib.rs
  - `load_payload` / `unload_payload` / `extract_geometry_session` を `registry.get()` 経由に変更

## Verification
- cargo test --no-default-features --features backend-openusd-rs: 43 passed, 25 ignored
- 既定 C++ backend 系の build / clippy: ローカル \`VCPKG_ROOT\` 未設定で未実行 (CI で確認推奨)

## Self-Review (Codex)
信頼度: 中
- registry map lock は Arc clone だけに短縮
- close 済み handle は即 lookup 不能、抽出中 handle は Arc lifetime で安全
- OpenSession は registry を持たないため Arc cycle なし
- 残課題: 既定 C++ backend での build / test を CI または vcpkg 環境で確認