### PR TITLE
refactor(usd): split UsdBackend into capability traits (#55)

### DIFF
--- a/src-tauri/src/bin/usd_to_glb.rs
+++ b/src-tauri/src/bin/usd_to_glb.rs
@@ -13,7 +13,7 @@
 
 use std::{path::PathBuf, process::ExitCode};
 
-use yw_look_lib::usd::{DefaultBackend, StageLoadPolicy, UsdBackend};
+use yw_look_lib::usd::{DefaultBackend, StageLoadPolicy, UsdGeometryBackend};
 
 fn main() -> ExitCode {
     let mut args = std::env::args().skip(1);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,12 +18,13 @@ use tauri::{Emitter, Manager};
 use tauri_plugin_updater::{Update, UpdaterExt};
 use url::Url;
 
+use crate::usd::types::ExtractGeometryOptions;
 use crate::usd::{
     AssetIssue, AttributeTimeSamples, DefaultBackend, OpenSession, PrimInspection,
-    StageInspection, StageLoadPolicy, StageRegistry, StageSummary, StageSessionHandle, UsdBackend,
+    StageInspection, StageLoadPolicy, StageRegistry, StageSummary, StageSessionHandle,
+    UsdGeometryBackend, UsdInspectBackend, UsdLightBackend, UsdSessionBackend, UsdSourceBackend,
     UsdError, UsdLightInfo,
 };
-use crate::usd::types::ExtractGeometryOptions;
 
 const SETTINGS_FILE_NAME: &str = "settings.json";
 const RECENT_FILES_FILE_NAME: &str = "recent-files.json";
@@ -112,19 +113,94 @@ const OPEN_FILE_EVENT: &str = "yw-look://open-file";
 #[derive(Default)]
 struct PendingOpenFiles(Mutex<Vec<PathBuf>>);
 
-/// Active USD inspection backend. Held behind an `Arc` so each async
-/// Tauri command can clone a handle and move it into a blocking task
-/// without borrowing from `tauri::State`.
-/// Currently `OpenusdBackend` (yohawing/openusd `yw-look-phase1`).
-struct UsdBackendState(Arc<dyn UsdBackend>);
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BackendCapabilities {
+    inspect: bool,
+    geometry: bool,
+    source: bool,
+    session: bool,
+    light: bool,
+}
+
+/// Active USD backend capabilities. Each optional slot advertises whether
+/// the selected backend can satisfy that command family.
+struct UsdBackendState {
+    inspect: Arc<dyn UsdInspectBackend>,
+    geometry: Option<Arc<dyn UsdGeometryBackend>>,
+    source: Option<Arc<dyn UsdSourceBackend>>,
+    session: Option<Arc<dyn UsdSessionBackend>>,
+    light: Option<Arc<dyn UsdLightBackend>>,
+}
 
 impl UsdBackendState {
-    fn new(backend: impl UsdBackend + 'static) -> Self {
-        Self(Arc::new(backend))
+    #[cfg(feature = "backend-openusd-cpp")]
+    fn new(backend: DefaultBackend) -> Self {
+        let backend = Arc::new(backend);
+        Self {
+            inspect: backend.clone() as Arc<dyn UsdInspectBackend>,
+            geometry: Some(backend.clone() as Arc<dyn UsdGeometryBackend>),
+            source: Some(backend.clone() as Arc<dyn UsdSourceBackend>),
+            session: Some(backend.clone() as Arc<dyn UsdSessionBackend>),
+            light: Some(backend as Arc<dyn UsdLightBackend>),
+        }
     }
 
-    fn handle(&self) -> Arc<dyn UsdBackend> {
-        Arc::clone(&self.0)
+    #[cfg(all(
+        feature = "backend-openusd-rs",
+        not(feature = "backend-openusd-cpp"),
+    ))]
+    fn new(backend: DefaultBackend) -> Self {
+        let backend = Arc::new(backend);
+        Self {
+            inspect: backend.clone() as Arc<dyn UsdInspectBackend>,
+            geometry: Some(backend as Arc<dyn UsdGeometryBackend>),
+            source: None,
+            session: None,
+            light: None,
+        }
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            inspect: true,
+            geometry: self.geometry.is_some(),
+            source: self.source.is_some(),
+            session: self.session.is_some(),
+            light: self.light.is_some(),
+        }
+    }
+
+    fn inspect(&self) -> Arc<dyn UsdInspectBackend> {
+        Arc::clone(&self.inspect)
+    }
+
+    fn geometry(&self) -> Result<Arc<dyn UsdGeometryBackend>, String> {
+        self.geometry
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| "USD backend capability unavailable: geometry".to_string())
+    }
+
+    fn source(&self) -> Result<Arc<dyn UsdSourceBackend>, String> {
+        self.source
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| "USD backend capability unavailable: source".to_string())
+    }
+
+    fn session(&self) -> Result<Arc<dyn UsdSessionBackend>, String> {
+        self.session
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| "USD backend capability unavailable: session".to_string())
+    }
+
+    fn light(&self) -> Result<Arc<dyn UsdLightBackend>, String> {
+        self.light
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| "USD backend capability unavailable: light".to_string())
     }
 }
 
@@ -1583,6 +1659,14 @@ where
         .map_err(map_usd_error)
 }
 
+#[allow(non_snake_case)]
+#[tauri::command]
+async fn backendCapabilities(
+    backend: tauri::State<'_, UsdBackendState>,
+) -> Result<BackendCapabilities, String> {
+    Ok(backend.capabilities())
+}
+
 #[tauri::command]
 async fn inspect_stage(
     backend: tauri::State<'_, UsdBackendState>,
@@ -1592,7 +1676,7 @@ async fn inspect_stage(
     policy: Option<StageLoadPolicy>,
 ) -> Result<StageInspection, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.inspect();
     let policy = policy.unwrap_or_default();
     run_blocking_usd(move || handle.inspect_stage(&normalized, policy)).await
 }
@@ -1612,7 +1696,7 @@ async fn inspect_attribute_time_samples(
 ) -> Result<AttributeTimeSamples, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
     let cap = max_samples.unwrap_or(100);
-    let handle = backend.handle();
+    let handle = backend.inspect();
     run_blocking_usd(move || {
         handle.inspect_attribute_time_samples(&normalized, &prim_path, &attr_name, cap)
     })
@@ -1630,7 +1714,7 @@ async fn inspect_prim(
     prim_path: String,
 ) -> Result<PrimInspection, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.inspect();
     run_blocking_usd(move || handle.inspect_prim(&normalized, &prim_path)).await
 }
 
@@ -1647,7 +1731,7 @@ async fn inspect_usd_lights(
     path: String,
 ) -> Result<Vec<UsdLightInfo>, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.light()?;
     run_blocking_usd(move || handle.inspect_usd_lights(&normalized)).await
 }
 
@@ -1658,7 +1742,7 @@ async fn summarize_stage(
     policy: Option<StageLoadPolicy>,
 ) -> Result<StageSummary, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.inspect();
     let policy = policy.unwrap_or_default();
     run_blocking_usd(move || handle.summarize_stage(&normalized, policy)).await
 }
@@ -1670,7 +1754,7 @@ async fn collect_asset_issues(
 ) -> Result<Vec<AssetIssue>, String> {
     // Asset issues always run under LoadAll — see the backend impl.
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.inspect();
     run_blocking_usd(move || handle.collect_asset_issues(&normalized)).await
 }
 
@@ -1690,7 +1774,7 @@ async fn requires_glb_preview(
     path: String,
 ) -> Result<bool, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.inspect();
     run_blocking_usd(move || handle.requires_glb_preview(&normalized)).await
 }
 
@@ -1716,7 +1800,7 @@ async fn extract_geometry(
     options: Option<crate::usd::types::ExtractGeometryOptions>,
 ) -> Result<tauri::ipc::Response, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.geometry()?;
     let resolved_options = options.unwrap_or_else(|| {
         crate::usd::types::ExtractGeometryOptions::from(policy.unwrap_or_default())
     });
@@ -1740,7 +1824,7 @@ async fn flatten_stage(
     path: String,
 ) -> Result<String, String> {
     let normalized = normalize_file_path(PathBuf::from(path))?;
-    let handle = backend.handle();
+    let handle = backend.source()?;
     run_blocking_usd(move || handle.flatten_stage(&normalized)).await
 }
 
@@ -1762,7 +1846,7 @@ async fn open_stage_session(
     policy: Option<StageLoadPolicy>,
 ) -> Result<StageSessionHandle, String> {
     let normalized = normalize_file_path(PathBuf::from(path.clone()))?;
-    let handle = backend.handle();
+    let handle = backend.session()?;
     let policy = policy.unwrap_or_default();
     let open_stage = run_blocking_usd(move || {
         handle.open_stage_session(&normalized, policy)
@@ -1805,7 +1889,7 @@ async fn load_payload(
     prim_path: String,
 ) -> Result<(), String> {
     use tauri::Manager;
-    let backend_handle = backend.handle();
+    let backend_handle = backend.session()?;
     // `UsdStage::Load` performs synchronous composition + I/O for
     // potentially large layers; route it through the blocking pool so
     // the async runtime stays responsive to other IPC traffic.
@@ -1836,7 +1920,7 @@ async fn unload_payload(
     prim_path: String,
 ) -> Result<(), String> {
     use tauri::Manager;
-    let backend_handle = backend.handle();
+    let backend_handle = backend.session()?;
     // Unload is cheaper than load but still touches `UsdStage`'s
     // composition cache; keep it off the async runtime for symmetry
     // and to guarantee the registry mutex isn't held across `.await`.
@@ -1870,7 +1954,7 @@ async fn extract_geometry_session(
     let resolved_options = options.unwrap_or_else(|| {
         ExtractGeometryOptions::from(policy.unwrap_or_default())
     });
-    let backend_handle = backend.handle();
+    let backend_handle = backend.session()?;
     // Heavy USD GLB extraction must not run on the async runtime's worker.
     // Move it to a blocking task and look up the registry from `app` inside
     // (avoids holding a `tauri::State` reference across `.await`).
@@ -2057,6 +2141,7 @@ pub fn run() {
             install_pending_update,
             inspect_asset,
             load_format_support,
+            backendCapabilities,
             inspect_stage,
             summarize_stage,
             collect_asset_issues,

--- a/src-tauri/src/usd/backend.rs
+++ b/src-tauri/src/usd/backend.rs
@@ -35,12 +35,12 @@ impl std::fmt::Display for UsdError {
 
 impl std::error::Error for UsdError {}
 
-/// The single contract every USD parser implementation must satisfy.
+/// Stage and prim inspection capability.
 ///
 /// Implementations are expected to be cheap to construct and safe to
 /// share across threads — Tauri's command runtime may invoke them from
 /// a worker pool.
-pub trait UsdBackend: Send + Sync {
+pub trait UsdInspectBackend: Send + Sync {
     /// Heavyweight inspection. Walks references / payloads according to
     /// `policy`. `StageLoadPolicy::NoPayloads` causes payload arcs to
     /// be surfaced as `CompositionArcState::Unloaded` instead of being
@@ -70,7 +70,7 @@ pub trait UsdBackend: Send + Sync {
     /// Phase 3: returns `true` if the root layer of the stage is the binary
     /// USDC crate format, `false` if it's USDA text. Kept as a primitive
     /// for tests and diagnostics — the frontend should consult
-    /// [`Self::requires_glb_preview`] instead, which also accounts for
+    /// `requires_glb_preview` instead, which also accounts for
     /// composition arcs.
     #[allow(dead_code)] // diagnostic-only, exercised by `#[cfg(test)]` paths
     fn root_layer_is_binary(&self, path: &Path) -> Result<bool, UsdError>;
@@ -91,17 +91,6 @@ pub trait UsdBackend: Send + Sync {
     /// transparently handles references and (loaded-mode) payloads.
     fn requires_glb_preview(&self, path: &Path) -> Result<bool, UsdError>;
 
-    /// Phase 3: extracts all Mesh prims from the stage and serializes them
-    /// to a self-contained GLB binary, returned as raw bytes. The frontend
-    /// receives this via `tauri::ipc::Response` and feeds it to
-    /// `GLTFLoader.parseAsync`. `policy` is forwarded to the backend so
-    /// `NoPayloads` builds a GLB containing only payload-free meshes.
-    fn extract_geometry_glb(
-        &self,
-        path: &Path,
-        policy: StageLoadPolicy,
-    ) -> Result<Vec<u8>, UsdError>;
-
     /// #28: per-prim attribute / relationship / metadata inspector.
     /// Returns a [`PrimInspection`] containing all authored attributes,
     /// relationships, and metadata on the prim at `prim_path`.
@@ -111,11 +100,7 @@ pub trait UsdBackend: Send + Sync {
     ///
     /// Backends that do not yet implement this should return
     /// `Err(UsdError::Parse("not supported on this backend".into()))`.
-    fn inspect_prim(
-        &self,
-        path: &Path,
-        prim_path: &str,
-    ) -> Result<PrimInspection, UsdError>;
+    fn inspect_prim(&self, path: &Path, prim_path: &str) -> Result<PrimInspection, UsdError>;
 
     /// #37: enumerates up to `max_samples` time samples on the named
     /// attribute and computes optional numeric statistics. `path` is the
@@ -131,14 +116,27 @@ pub trait UsdBackend: Send + Sync {
         attr_name: &str,
         max_samples: usize,
     ) -> Result<AttributeTimeSamples, UsdError>;
+}
+
+/// Mesh extraction / GLB generation capability.
+pub trait UsdGeometryBackend: Send + Sync {
+    /// Phase 3: extracts all Mesh prims from the stage and serializes them
+    /// to a self-contained GLB binary, returned as raw bytes. The frontend
+    /// receives this via `tauri::ipc::Response` and feeds it to
+    /// `GLTFLoader.parseAsync`. `policy` is forwarded to the backend so
+    /// `NoPayloads` builds a GLB containing only payload-free meshes.
+    fn extract_geometry_glb(
+        &self,
+        path: &Path,
+        policy: StageLoadPolicy,
+    ) -> Result<Vec<u8>, UsdError>;
 
     /// Round 1.5 (#32 / #31 plumbing): options-aware variant of
-    /// [`Self::extract_geometry_glb`]. Default delegates to the
-    /// policy-only method, ignoring `variant_selections` and
-    /// `purpose_modes`. Backends that support those features override
-    /// this method to consume the options. Frontend / Tauri command
-    /// callers should prefer this method so variant / purpose changes
-    /// take effect on backends that implement them.
+    /// `extract_geometry_glb`. Default delegates to the policy-only method,
+    /// ignoring `variant_selections` and `purpose_modes`. Backends that
+    /// support those features override this method to consume the options.
+    /// Frontend / Tauri command callers should prefer this method so variant
+    /// / purpose changes take effect on backends that implement them.
     fn extract_geometry_glb_with_options(
         &self,
         path: &Path,
@@ -146,7 +144,10 @@ pub trait UsdBackend: Send + Sync {
     ) -> Result<Vec<u8>, UsdError> {
         self.extract_geometry_glb(path, options.policy)
     }
+}
 
+/// Source layer export / flattening capability.
+pub trait UsdSourceBackend: Send + Sync {
     /// #39 — returns the fully flattened USDA text of the stage,
     /// equivalent to `usdcat --flatten`. Every reference, payload, and
     /// sublayer is composed and inlined into the returned string.
@@ -160,7 +161,10 @@ pub trait UsdBackend: Send + Sync {
     /// `{ kind: "binary" }` — for USDA stages the raw layer text already
     /// provides the source view without the overhead of full composition.
     fn flatten_stage(&self, path: &Path) -> Result<String, UsdError>;
+}
 
+/// USD light detail inspection capability.
+pub trait UsdLightBackend: Send + Sync {
     /// #35 — enumerates all UsdLux light prims in the stage and returns
     /// their detailed attributes (intensity, color, exposure, color
     /// temperature, specular/diffuse multipliers, shaping cone, dome texture).
@@ -171,14 +175,10 @@ pub trait UsdBackend: Send + Sync {
     /// an error from this method as "no USD light detail available" and fall
     /// back to the Three.js-derived `LightEntry` list.
     fn inspect_usd_lights(&self, path: &Path) -> Result<Vec<UsdLightInfo>, UsdError>;
+}
 
-    // -----------------------------------------------------------------------
-    // #44 — stateful per-prim payload session API
-    // -----------------------------------------------------------------------
-    //
-    // These methods must be in the same trait (not a sub-trait) so the existing
-    // `Arc<dyn UsdBackend>` state can call them without any downcasting.
-
+/// Stateful stage session / per-prim payload capability.
+pub trait UsdSessionBackend: Send + Sync {
     /// Opens `path` under `policy` and returns a backend-specific stage
     /// handle that the caller stores in `StageRegistry`. Unlike
     /// `extract_geometry_glb`, this does NOT keep the stage alive only for
@@ -199,20 +199,12 @@ pub trait UsdBackend: Send + Sync {
     /// `Err(UsdError::Parse("per-prim payload load not supported …"))` because
     /// the openusd crate only supports stage-wide load policies (D6 from the
     /// plan). The C++ backend calls `UsdStage::Load(SdfPath, UsdLoadPolicy)`.
-    fn load_payload(
-        &self,
-        stage: &OpenStage,
-        prim_path: &str,
-    ) -> Result<(), UsdError>;
+    fn load_payload(&self, stage: &OpenStage, prim_path: &str) -> Result<(), UsdError>;
 
     /// Unloads the payload arc(s) rooted at `prim_path` on an open stage.
     ///
     /// Same backend caveat as [`Self::load_payload`].
-    fn unload_payload(
-        &self,
-        stage: &OpenStage,
-        prim_path: &str,
-    ) -> Result<(), UsdError>;
+    fn unload_payload(&self, stage: &OpenStage, prim_path: &str) -> Result<(), UsdError>;
 
     /// Runs the GLB extraction pipeline on an already-open stage (i.e. the
     /// same `extract_geometry_from_open_stage` helper, but reached through the

--- a/src-tauri/src/usd/cpp_sys/mod.rs
+++ b/src-tauri/src/usd/cpp_sys/mod.rs
@@ -166,12 +166,9 @@ impl CStage {
         // no longer matches the file on disk. The Rust fork backend
         // also errors out on non-UTF-8 paths, so the two backends
         // stay consistent for Tauri callers that compare results.
-        let path_str = path.to_str().ok_or_else(|| {
-            CError(format!(
-                "path is not valid UTF-8: {}",
-                path.display()
-            ))
-        })?;
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| CError(format!("path is not valid UTF-8: {}", path.display())))?;
         let c_path = CString::new(path_str)
             .map_err(|_| CError("path contains interior NUL byte".to_string()))?;
         let mut err: *mut UsdcError = std::ptr::null_mut();
@@ -236,28 +233,44 @@ impl CStage {
     pub fn authored_time_codes_per_second(&self) -> Option<f64> {
         let mut out: f64 = 0.0;
         let ok = unsafe { usdc_stage_authored_time_codes_per_second(self.raw, &mut out) };
-        if ok != 0 { Some(out) } else { None }
+        if ok != 0 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// Stage `framesPerSecond` authored on the root layer.
     pub fn authored_frames_per_second(&self) -> Option<f64> {
         let mut out: f64 = 0.0;
         let ok = unsafe { usdc_stage_authored_frames_per_second(self.raw, &mut out) };
-        if ok != 0 { Some(out) } else { None }
+        if ok != 0 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// Stage `startTimeCode` authored on the root layer.
     pub fn authored_start_time_code(&self) -> Option<f64> {
         let mut out: f64 = 0.0;
         let ok = unsafe { usdc_stage_authored_start_time_code(self.raw, &mut out) };
-        if ok != 0 { Some(out) } else { None }
+        if ok != 0 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// Stage `endTimeCode` authored on the root layer.
     pub fn authored_end_time_code(&self) -> Option<f64> {
         let mut out: f64 = 0.0;
         let ok = unsafe { usdc_stage_authored_end_time_code(self.raw, &mut out) };
-        if ok != 0 { Some(out) } else { None }
+        if ok != 0 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// Stage `comment` authored on the root layer, or `None` when
@@ -452,7 +465,9 @@ impl CStage {
             Ok(c) => c,
             Err(_) => return false,
         };
-        unsafe { usdc_prim_set_variant_selection(self.raw, p.as_ptr(), s.as_ptr(), v.as_ptr()) != 0 }
+        unsafe {
+            usdc_prim_set_variant_selection(self.raw, p.as_ptr(), s.as_ptr(), v.as_ptr()) != 0
+        }
     }
 
     fn arcs<F>(&self, prim_path: &str, call: F) -> Vec<Arc>
@@ -568,7 +583,11 @@ impl CStage {
         let ok = unsafe {
             usdc_prim_attr_float(self.raw, pp.as_ptr(), an.as_ptr(), &mut out as *mut f32)
         };
-        if ok == 1 { Some(out) } else { None }
+        if ok == 1 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// float2 / double2 attribute (e.g. `UsdGeomCamera.clippingRange`).
@@ -576,10 +595,13 @@ impl CStage {
         let pp = CString::new(prim_path).ok()?;
         let an = CString::new(attr_name).ok()?;
         let mut out: [f32; 2] = [0.0; 2];
-        let ok = unsafe {
-            usdc_prim_attr_float2(self.raw, pp.as_ptr(), an.as_ptr(), out.as_mut_ptr())
-        };
-        if ok == 1 { Some(out) } else { None }
+        let ok =
+            unsafe { usdc_prim_attr_float2(self.raw, pp.as_ptr(), an.as_ptr(), out.as_mut_ptr()) };
+        if ok == 1 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// Reads a token attribute on a prim (e.g.
@@ -684,10 +706,13 @@ impl CStage {
         let pp = CString::new(prim_path).ok()?;
         let an = CString::new(attr_name).ok()?;
         let mut out: [f32; 3] = [0.0; 3];
-        let ok = unsafe {
-            usdc_prim_attr_color3f(self.raw, pp.as_ptr(), an.as_ptr(), out.as_mut_ptr())
-        };
-        if ok == 1 { Some(out) } else { None }
+        let ok =
+            unsafe { usdc_prim_attr_color3f(self.raw, pp.as_ptr(), an.as_ptr(), out.as_mut_ptr()) };
+        if ok == 1 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// Direct `UsdShadeMaterialBinding` lookup (allPurpose) on a prim.
@@ -725,7 +750,11 @@ impl CStage {
         let ok = unsafe {
             usdc_shader_input_float(self.raw, sp.as_ptr(), ip.as_ptr(), &mut out as *mut f32)
         };
-        if ok == 1 { Some(out) } else { None }
+        if ok == 1 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// First connected source prim for a named shader input. For
@@ -739,9 +768,8 @@ impl CStage {
     ) -> Option<String> {
         let sp = CString::new(shader_path).ok()?;
         let ip = CString::new(input_name).ok()?;
-        let p = unsafe {
-            usdc_shader_input_connected_source_prim(self.raw, sp.as_ptr(), ip.as_ptr())
-        };
+        let p =
+            unsafe { usdc_shader_input_connected_source_prim(self.raw, sp.as_ptr(), ip.as_ptr()) };
         ptr_to_opt_string(p)
     }
 
@@ -762,11 +790,13 @@ impl CStage {
     /// `UsdPreviewSurface.inputs:diffuseColor` is driven by a texture
     /// we have not yet loaded.
     pub fn shader_input_has_connection(&self, shader_path: &str, input_name: &str) -> bool {
-        let Ok(sp) = CString::new(shader_path) else { return false };
-        let Ok(ip) = CString::new(input_name) else { return false };
-        let ok = unsafe {
-            usdc_shader_input_has_connection(self.raw, sp.as_ptr(), ip.as_ptr())
+        let Ok(sp) = CString::new(shader_path) else {
+            return false;
         };
+        let Ok(ip) = CString::new(input_name) else {
+            return false;
+        };
+        let ok = unsafe { usdc_shader_input_has_connection(self.raw, sp.as_ptr(), ip.as_ptr()) };
         ok == 1
     }
 
@@ -779,7 +809,11 @@ impl CStage {
         let ok = unsafe {
             usdc_shader_input_color3f(self.raw, sp.as_ptr(), ip.as_ptr(), out.as_mut_ptr())
         };
-        if ok == 1 { Some(out) } else { None }
+        if ok == 1 {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     // -------- UsdSkel (Phase 2.G) --------
@@ -940,11 +974,7 @@ impl CStage {
     /// Flat `float[]` parallel to the animation's `blendShapes`
     /// token array — map each weight back to a channel name by
     /// reading `blendShapes` via `prim_attr_token_array`.
-    pub fn skel_anim_blend_shape_weights_at(
-        &self,
-        anim_path: &str,
-        time: f64,
-    ) -> Vec<f32> {
+    pub fn skel_anim_blend_shape_weights_at(&self, anim_path: &str, time: f64) -> Vec<f32> {
         let Ok(c) = CString::new(anim_path) else {
             return Vec::new();
         };
@@ -1011,44 +1041,40 @@ impl CStage {
     /// Arrays → `"[N elements]"`, scalars are stringified.
     /// Returns empty string when unauthored, `None` when the attribute
     /// does not exist.
-    pub fn prim_attribute_value_summary(
-        &self,
-        prim_path: &str,
-        attr_name: &str,
-    ) -> Option<String> {
+    pub fn prim_attribute_value_summary(&self, prim_path: &str, attr_name: &str) -> Option<String> {
         let pp = CString::new(prim_path).ok()?;
         let an = CString::new(attr_name).ok()?;
-        let p = unsafe {
-            usdc_prim_attribute_value_summary(self.raw, pp.as_ptr(), an.as_ptr())
-        };
+        let p = unsafe { usdc_prim_attribute_value_summary(self.raw, pp.as_ptr(), an.as_ptr()) };
         // The shim returns "" for unauthored (not NULL), so we map
         // that differently from the "attr not found" NULL case.
         if p.is_null() {
             None
         } else {
-            Some(unsafe { std::ffi::CStr::from_ptr(p) }.to_string_lossy().into_owned())
+            Some(
+                unsafe { std::ffi::CStr::from_ptr(p) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
         }
     }
 
     /// `true` if the attribute is custom (not schema-defined).
     pub fn prim_attribute_is_custom(&self, prim_path: &str, attr_name: &str) -> bool {
-        let Ok(pp) = CString::new(prim_path) else { return false; };
-        let Ok(an) = CString::new(attr_name) else { return false; };
+        let Ok(pp) = CString::new(prim_path) else {
+            return false;
+        };
+        let Ok(an) = CString::new(attr_name) else {
+            return false;
+        };
         unsafe { usdc_prim_attribute_is_custom(self.raw, pp.as_ptr(), an.as_ptr()) != 0 }
     }
 
     /// Variability string: `"varying"` or `"uniform"`.
     /// `None` when the attribute does not exist.
-    pub fn prim_attribute_variability(
-        &self,
-        prim_path: &str,
-        attr_name: &str,
-    ) -> Option<String> {
+    pub fn prim_attribute_variability(&self, prim_path: &str, attr_name: &str) -> Option<String> {
         let pp = CString::new(prim_path).ok()?;
         let an = CString::new(attr_name).ok()?;
-        let p = unsafe {
-            usdc_prim_attribute_variability(self.raw, pp.as_ptr(), an.as_ptr())
-        };
+        let p = unsafe { usdc_prim_attribute_variability(self.raw, pp.as_ptr(), an.as_ptr()) };
         ptr_to_opt_string(p)
     }
 
@@ -1056,12 +1082,19 @@ impl CStage {
     /// Returns `0` when there are no samples or the attribute does not
     /// exist.
     pub fn prim_attribute_time_sample_count(&self, prim_path: &str, attr_name: &str) -> usize {
-        let Ok(pp) = CString::new(prim_path) else { return 0; };
-        let Ok(an) = CString::new(attr_name) else { return 0; };
-        let n = unsafe {
-            usdc_prim_attribute_time_sample_count(self.raw, pp.as_ptr(), an.as_ptr())
+        let Ok(pp) = CString::new(prim_path) else {
+            return 0;
         };
-        if n < 0 { 0 } else { n as usize }
+        let Ok(an) = CString::new(attr_name) else {
+            return 0;
+        };
+        let n =
+            unsafe { usdc_prim_attribute_time_sample_count(self.raw, pp.as_ptr(), an.as_ptr()) };
+        if n < 0 {
+            0
+        } else {
+            n as usize
+        }
     }
 
     /// Enumerates up to `max_samples` time samples on the attribute,
@@ -1115,8 +1148,12 @@ impl CStage {
 
     /// Forwarded target paths of the named relationship.
     pub fn prim_relationship_targets(&self, prim_path: &str, rel_name: &str) -> Vec<String> {
-        let Ok(pp) = CString::new(prim_path) else { return Vec::new(); };
-        let Ok(rn) = CString::new(rel_name) else { return Vec::new(); };
+        let Ok(pp) = CString::new(prim_path) else {
+            return Vec::new();
+        };
+        let Ok(rn) = CString::new(rel_name) else {
+            return Vec::new();
+        };
         let mut out = Vec::<String>::new();
         unsafe {
             usdc_prim_relationship_targets(
@@ -1149,16 +1186,10 @@ impl CStage {
 
     /// Human-readable summary of a prim's metadata value for `key`.
     /// `None` when the key is not authored or the prim does not exist.
-    pub fn prim_metadata_value_summary(
-        &self,
-        prim_path: &str,
-        key: &str,
-    ) -> Option<String> {
+    pub fn prim_metadata_value_summary(&self, prim_path: &str, key: &str) -> Option<String> {
         let pp = CString::new(prim_path).ok()?;
         let kk = CString::new(key).ok()?;
-        let p = unsafe {
-            usdc_prim_metadata_value_summary(self.raw, pp.as_ptr(), kk.as_ptr())
-        };
+        let p = unsafe { usdc_prim_metadata_value_summary(self.raw, pp.as_ptr(), kk.as_ptr()) };
         ptr_to_opt_string(p)
     }
 
@@ -1193,7 +1224,11 @@ impl CStage {
             return 0;
         };
         let n = unsafe { usdc_mesh_joints_per_vertex(self.raw, c.as_ptr()) };
-        if n > 0 { n as usize } else { 0 }
+        if n > 0 {
+            n as usize
+        } else {
+            0
+        }
     }
 
     fn read_float_attr<F>(&self, prim_path: &str, call: F) -> Vec<f32>
@@ -1228,18 +1263,9 @@ impl CStage {
         out
     }
 
-    fn read_float_attr_with_interp<F>(
-        &self,
-        prim_path: &str,
-        call: F,
-    ) -> (Vec<f32>, Interpolation)
+    fn read_float_attr_with_interp<F>(&self, prim_path: &str, call: F) -> (Vec<f32>, Interpolation)
     where
-        F: FnOnce(
-            *const c_char,
-            UsdcFloatBufferCallback,
-            *mut c_void,
-            *mut UsdcInterpolation,
-        ),
+        F: FnOnce(*const c_char, UsdcFloatBufferCallback, *mut c_void, *mut UsdcInterpolation),
     {
         let Ok(c) = CString::new(prim_path) else {
             return (Vec::new(), Interpolation::Unknown);
@@ -1326,7 +1352,9 @@ impl CStage {
     /// Returns `true` if the prim at `prim_path` is typed as
     /// `UsdGeomPointInstancer`, `false` for any other type or missing prim.
     pub fn is_point_instancer(&self, prim_path: &str) -> bool {
-        let Ok(c) = CString::new(prim_path) else { return false };
+        let Ok(c) = CString::new(prim_path) else {
+            return false;
+        };
         unsafe { usdc_prim_is_point_instancer(self.raw, c.as_ptr()) != 0 }
     }
 
@@ -1334,7 +1362,9 @@ impl CStage {
     /// `UsdGeomPointInstancer` prim. Returns an empty `Vec` when the prim
     /// does not exist, is not a PointInstancer, or has no prototypes.
     pub fn point_instancer_prototypes(&self, prim_path: &str) -> Vec<String> {
-        let Ok(c) = CString::new(prim_path) else { return Vec::new() };
+        let Ok(c) = CString::new(prim_path) else {
+            return Vec::new();
+        };
         let mut out = Vec::<String>::new();
         unsafe {
             usdc_point_instancer_prototypes(
@@ -1350,7 +1380,9 @@ impl CStage {
     /// Reads `protoIndices` (int[]) from a PointInstancer prim at the
     /// default time code. Returns an empty `Vec` when unauthored.
     pub fn point_instancer_proto_indices(&self, prim_path: &str) -> Vec<i32> {
-        let Ok(c) = CString::new(prim_path) else { return Vec::new() };
+        let Ok(c) = CString::new(prim_path) else {
+            return Vec::new();
+        };
         let mut out = Vec::<i32>::new();
         unsafe {
             usdc_point_instancer_proto_indices(
@@ -1366,7 +1398,9 @@ impl CStage {
     /// Reads `positions` (point3f[]) from a PointInstancer prim.
     /// Returns a flat `[x0, y0, z0, x1, ...]` buffer; empty when unauthored.
     pub fn point_instancer_positions(&self, prim_path: &str) -> Vec<f32> {
-        let Ok(c) = CString::new(prim_path) else { return Vec::new() };
+        let Ok(c) = CString::new(prim_path) else {
+            return Vec::new();
+        };
         let mut out = Vec::<f32>::new();
         unsafe {
             usdc_point_instancer_positions(
@@ -1383,7 +1417,9 @@ impl CStage {
     /// to f32 and reordered to glTF convention [x, y, z, w]. Returns a flat
     /// buffer of length `count * 4`; empty when unauthored.
     pub fn point_instancer_orientations(&self, prim_path: &str) -> Vec<f32> {
-        let Ok(c) = CString::new(prim_path) else { return Vec::new() };
+        let Ok(c) = CString::new(prim_path) else {
+            return Vec::new();
+        };
         let mut out = Vec::<f32>::new();
         unsafe {
             usdc_point_instancer_orientations(
@@ -1399,7 +1435,9 @@ impl CStage {
     /// Reads `scales` (float3[]) from a PointInstancer prim.
     /// Returns a flat `[sx0, sy0, sz0, ...]` buffer; empty when unauthored.
     pub fn point_instancer_scales(&self, prim_path: &str) -> Vec<f32> {
-        let Ok(c) = CString::new(prim_path) else { return Vec::new() };
+        let Ok(c) = CString::new(prim_path) else {
+            return Vec::new();
+        };
         let mut out = Vec::<f32>::new();
         unsafe {
             usdc_point_instancer_scales(
@@ -1415,7 +1453,9 @@ impl CStage {
     /// Reads `invisibleIds` (int64[]) from a PointInstancer prim.
     /// Returns an empty `Vec` when unauthored.
     pub fn point_instancer_invisible_ids(&self, prim_path: &str) -> Vec<i64> {
-        let Ok(c) = CString::new(prim_path) else { return Vec::new() };
+        let Ok(c) = CString::new(prim_path) else {
+            return Vec::new();
+        };
         let mut out = Vec::<i64>::new();
         unsafe {
             usdc_point_instancer_invisible_ids(
@@ -1459,9 +1499,7 @@ unsafe extern "C" fn string_trampoline(s: *const c_char, user: *mut c_void) {
     if s.is_null() {
         return;
     }
-    let value = unsafe { CStr::from_ptr(s) }
-        .to_string_lossy()
-        .into_owned();
+    let value = unsafe { CStr::from_ptr(s) }.to_string_lossy().into_owned();
     out.push(value);
 }
 
@@ -1505,11 +1543,7 @@ unsafe extern "C" fn arc_trampoline(arc: *const UsdcArc, user: *mut c_void) {
 //   - `data` must point to `count` contiguous valid `f32`s (or be
 //     null with `count == 0`).
 //   - `user` must be a `*mut Vec<f32>` as set up by `read_float_attr`.
-unsafe extern "C" fn float_buffer_trampoline(
-    data: *const f32,
-    count: usize,
-    user: *mut c_void,
-) {
+unsafe extern "C" fn float_buffer_trampoline(data: *const f32, count: usize, user: *mut c_void) {
     if user.is_null() || data.is_null() || count == 0 {
         return;
     }
@@ -1548,11 +1582,7 @@ unsafe extern "C" fn time_sample_trampoline(
 // Same pattern for i32 integer buffers (faceVertexCounts / indices).
 // `c_int` on Windows MSVC and macOS x64/arm64 is 32-bit, so a reinterpret
 // to `i32` is safe for the platforms the C++ backend targets.
-unsafe extern "C" fn i32_buffer_trampoline(
-    data: *const c_int,
-    count: usize,
-    user: *mut c_void,
-) {
+unsafe extern "C" fn i32_buffer_trampoline(data: *const c_int, count: usize, user: *mut c_void) {
     if user.is_null() || data.is_null() || count == 0 {
         return;
     }
@@ -1571,10 +1601,7 @@ unsafe extern "C" fn i32_buffer_trampoline(
 //     we copy them immediately.
 //   - `user` must be a `*mut Vec<LayerInfo>` as set up by
 //     `CStage::layer_stack`.
-unsafe extern "C" fn layer_info_trampoline(
-    info: *const UsdcLayerInfo,
-    user: *mut c_void,
-) {
+unsafe extern "C" fn layer_info_trampoline(info: *const UsdcLayerInfo, user: *mut c_void) {
     if info.is_null() || user.is_null() {
         return;
     }
@@ -1607,11 +1634,7 @@ unsafe extern "C" fn layer_info_trampoline(
 //   - `data` must point to `count` contiguous valid `i64`s (or null / 0).
 //   - `user` must be a `*mut Vec<i64>` as set up by
 //     `CStage::point_instancer_invisible_ids`.
-unsafe extern "C" fn i64_buffer_trampoline(
-    data: *const i64,
-    count: usize,
-    user: *mut c_void,
-) {
+unsafe extern "C" fn i64_buffer_trampoline(data: *const i64, count: usize, user: *mut c_void) {
     if user.is_null() || data.is_null() || count == 0 {
         return;
     }
@@ -1630,10 +1653,7 @@ unsafe extern "C" fn i64_buffer_trampoline(
 //     we copy them immediately.
 //   - `user` must be a `*mut Vec<LightInfoRaw>` as set up by
 //     `CStage::lights`.
-unsafe extern "C" fn light_info_trampoline(
-    info: *const UsdcLightInfo,
-    user: *mut c_void,
-) {
+unsafe extern "C" fn light_info_trampoline(info: *const UsdcLightInfo, user: *mut c_void) {
     if info.is_null() || user.is_null() {
         return;
     }
@@ -1659,9 +1679,16 @@ unsafe extern "C" fn light_info_trampoline(
     } else {
         None
     };
-    let dome_texture_file = ptr_to_opt_string(r.dome_texture_file).and_then(|s| {
-        if s.is_empty() { None } else { Some(s) }
-    });
+    let dome_texture_file =
+        ptr_to_opt_string(r.dome_texture_file).and_then(
+            |s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            },
+        );
     let shaping_cone = if r.has_shaping_cone != 0 {
         Some(ShapingConeRaw {
             angle: r.shaping_cone_angle,

--- a/src-tauri/src/usd/glb.rs
+++ b/src-tauri/src/usd/glb.rs
@@ -603,7 +603,12 @@ pub struct InstancingInput {
 
 impl NodeInput {
     /// Convenience constructor for a pure hierarchy (Xform/Scope) node.
-    pub fn group(prim_path: String, basename: String, parent: Option<usize>, local_matrix: [f32; 16]) -> Self {
+    pub fn group(
+        prim_path: String,
+        basename: String,
+        parent: Option<usize>,
+        local_matrix: [f32; 16],
+    ) -> Self {
         Self {
             prim_path,
             basename,
@@ -853,10 +858,7 @@ pub fn build_glb(
     }
     for (i, t) in textures.iter().enumerate() {
         if t.data.is_empty() {
-            return Err(format!(
-                "texture[{i}] '{}' has empty image data",
-                t.name
-            ));
+            return Err(format!("texture[{i}] '{}' has empty image data", t.name));
         }
         if t.mime_type != "image/png" && t.mime_type != "image/jpeg" {
             return Err(format!(
@@ -1047,58 +1049,56 @@ pub fn build_glb(
         };
 
         // -- joint indices / weights (Phase 5c E) ------------------------
-        let (joints_accessor_idx, weights_accessor_idx) = match (
-            mesh.joint_indices.as_ref(),
-            mesh.joint_weights.as_ref(),
-        ) {
-            (Some(joint_idx), Some(joint_w)) => {
-                // JOINTS_0: VEC4 of unsigned shorts (component 5123).
-                let off_j = bin.len() as u64;
-                for &v in joint_idx {
-                    bin.extend_from_slice(&v.to_le_bytes());
-                }
-                let len_j = (bin.len() as u64) - off_j;
-                pad_to_4(&mut bin);
-                let view_j = buffer_views.len();
-                buffer_views.push(json!({
-                    "buffer": 0,
-                    "byteOffset": off_j,
-                    "byteLength": len_j,
-                    "target": 34962,
-                }));
-                let acc_j = accessors.len();
-                accessors.push(json!({
-                    "bufferView": view_j,
-                    "componentType": 5123, // UNSIGNED_SHORT
-                    "count": vertex_count,
-                    "type": "VEC4",
-                }));
+        let (joints_accessor_idx, weights_accessor_idx) =
+            match (mesh.joint_indices.as_ref(), mesh.joint_weights.as_ref()) {
+                (Some(joint_idx), Some(joint_w)) => {
+                    // JOINTS_0: VEC4 of unsigned shorts (component 5123).
+                    let off_j = bin.len() as u64;
+                    for &v in joint_idx {
+                        bin.extend_from_slice(&v.to_le_bytes());
+                    }
+                    let len_j = (bin.len() as u64) - off_j;
+                    pad_to_4(&mut bin);
+                    let view_j = buffer_views.len();
+                    buffer_views.push(json!({
+                        "buffer": 0,
+                        "byteOffset": off_j,
+                        "byteLength": len_j,
+                        "target": 34962,
+                    }));
+                    let acc_j = accessors.len();
+                    accessors.push(json!({
+                        "bufferView": view_j,
+                        "componentType": 5123, // UNSIGNED_SHORT
+                        "count": vertex_count,
+                        "type": "VEC4",
+                    }));
 
-                // WEIGHTS_0: VEC4 of FLOAT.
-                let off_w = bin.len() as u64;
-                for &v in joint_w {
-                    bin.extend_from_slice(&v.to_le_bytes());
+                    // WEIGHTS_0: VEC4 of FLOAT.
+                    let off_w = bin.len() as u64;
+                    for &v in joint_w {
+                        bin.extend_from_slice(&v.to_le_bytes());
+                    }
+                    let len_w = (bin.len() as u64) - off_w;
+                    pad_to_4(&mut bin);
+                    let view_w = buffer_views.len();
+                    buffer_views.push(json!({
+                        "buffer": 0,
+                        "byteOffset": off_w,
+                        "byteLength": len_w,
+                        "target": 34962,
+                    }));
+                    let acc_w = accessors.len();
+                    accessors.push(json!({
+                        "bufferView": view_w,
+                        "componentType": COMPONENT_TYPE_FLOAT,
+                        "count": vertex_count,
+                        "type": "VEC4",
+                    }));
+                    (Some(acc_j), Some(acc_w))
                 }
-                let len_w = (bin.len() as u64) - off_w;
-                pad_to_4(&mut bin);
-                let view_w = buffer_views.len();
-                buffer_views.push(json!({
-                    "buffer": 0,
-                    "byteOffset": off_w,
-                    "byteLength": len_w,
-                    "target": 34962,
-                }));
-                let acc_w = accessors.len();
-                accessors.push(json!({
-                    "bufferView": view_w,
-                    "componentType": COMPONENT_TYPE_FLOAT,
-                    "count": vertex_count,
-                    "type": "VEC4",
-                }));
-                (Some(acc_j), Some(acc_w))
-            }
-            _ => (None, None),
-        };
+                _ => (None, None),
+            };
 
         // -- mesh primitive ----------------------------------------------
         let mut attributes = serde_json::Map::new();
@@ -1267,8 +1267,7 @@ pub fn build_glb(
         // Allocate node indices for every joint up front so children
         // can reference parents that haven't been pushed yet.
         let base_node = gltf_nodes.len();
-        let joint_node_indices: Vec<usize> =
-            (base_node..base_node + joint_count).collect();
+        let joint_node_indices: Vec<usize> = (base_node..base_node + joint_count).collect();
 
         // Build a children list per joint by walking parents.
         let mut children: Vec<Vec<usize>> = vec![Vec::new(); joint_count];
@@ -1317,10 +1316,11 @@ pub fn build_glb(
         // When the hierarchy-aware path is used (nodes slice is non-empty),
         // the SkelRoot node itself provides this transform and the wrapper
         // is emitted only in the legacy flat path.
-        let emit_legacy_wrapper = nodes.is_empty() && match skin.skel_root_matrix {
-            Some(m) => !is_identity_mat4_f32(&m),
-            None => false,
-        };
+        let emit_legacy_wrapper = nodes.is_empty()
+            && match skin.skel_root_matrix {
+                Some(m) => !is_identity_mat4_f32(&m),
+                None => false,
+            };
         if emit_legacy_wrapper {
             let wrapper_idx = gltf_nodes.len();
             let m = skin.skel_root_matrix.expect("checked above");
@@ -1674,8 +1674,7 @@ pub fn build_glb(
         // minimal for the (common) no-emission case.
         let emissive = m.emissive_factor;
         if emissive[0] > 0.0 || emissive[1] > 0.0 || emissive[2] > 0.0 {
-            material["emissiveFactor"] =
-                json!([emissive[0], emissive[1], emissive[2]]);
+            material["emissiveFactor"] = json!([emissive[0], emissive[1], emissive[2]]);
         }
         // Phase 2.M: alpha mode selection. UsdPreviewSurface has two
         // dimensions — a scalar `opacity` that lands on
@@ -1732,10 +1731,10 @@ pub fn build_glb(
         // Map NodeInput index → glTF node index (into gltf_nodes).
         // We pre-allocate all node slots now; index 0 is the __upAxis node.
         let up_axis_gltf_idx: usize = gltf_nodes.len(); // current length = 0 for first call
-        // Reserve the __upAxis node slot.
+                                                        // Reserve the __upAxis node slot.
         gltf_nodes.push(Value::Null); // placeholder, filled below
         let node_input_base = gltf_nodes.len(); // first real NodeInput node
-        // Allocate all NodeInput nodes in order.
+                                                // Allocate all NodeInput nodes in order.
         for ni in nodes.iter() {
             let gltf_idx = gltf_nodes.len();
             let _ = (ni, gltf_idx); // used below
@@ -1810,7 +1809,9 @@ pub fn build_glb(
                     obj
                 }
                 NodeKind::Mesh => {
-                    let mesh_idx = ni.mesh_payload_idx.expect("Mesh node must have mesh_payload_idx");
+                    let mesh_idx = ni
+                        .mesh_payload_idx
+                        .expect("Mesh node must have mesh_payload_idx");
                     let mesh = &meshes[mesh_idx];
                     let gltf_mesh_idx = mesh_idx; // 1:1 mapping: meshes[i] → gltf_meshes[i]
                     mesh_node_indices[mesh_idx] = gltf_idx;
@@ -1834,7 +1835,9 @@ pub fn build_glb(
                     obj
                 }
                 NodeKind::Light => {
-                    let light_idx_payload = ni.light_payload_idx.expect("Light node must have light_payload_idx");
+                    let light_idx_payload = ni
+                        .light_payload_idx
+                        .expect("Light node must have light_payload_idx");
                     // The light definition index matches light_payload_idx since we build
                     // light defs in the loop below in the same order as `lights` slice.
                     let mut obj = json!({
@@ -1854,7 +1857,9 @@ pub fn build_glb(
                     obj
                 }
                 NodeKind::Camera => {
-                    let cam_idx_payload = ni.camera_payload_idx.expect("Camera node must have camera_payload_idx");
+                    let cam_idx_payload = ni
+                        .camera_payload_idx
+                        .expect("Camera node must have camera_payload_idx");
                     let mut obj = json!({
                         "name": ni.basename,
                         "matrix": local_mat,
@@ -1868,7 +1873,9 @@ pub fn build_glb(
                     obj
                 }
                 NodeKind::SkelRoot => {
-                    let skin_idx_payload = ni.skin_payload_idx.expect("SkelRoot node must have skin_payload_idx");
+                    let skin_idx_payload = ni
+                        .skin_payload_idx
+                        .expect("SkelRoot node must have skin_payload_idx");
                     // Children of a SkelRoot include: hierarchy children from NodeInput,
                     // plus the joint roots that belong to this skin.
                     let children_gltf_base: Vec<usize> = children_of[ni_idx].clone();
@@ -2057,8 +2064,12 @@ pub fn build_glb(
             ([f32::INFINITY; 3], [f32::NEG_INFINITY; 3]),
             |(mut mn, mut mx), t| {
                 for i in 0..3 {
-                    if t[i] < mn[i] { mn[i] = t[i]; }
-                    if t[i] > mx[i] { mx[i] = t[i]; }
+                    if t[i] < mn[i] {
+                        mn[i] = t[i];
+                    }
+                    if t[i] > mx[i] {
+                        mx[i] = t[i];
+                    }
                 }
                 (mn, mx)
             },
@@ -2281,8 +2292,8 @@ pub fn build_glb(
         document["animations"] = Value::Array(gltf_animations);
     }
 
-    let mut json_bytes = serde_json::to_vec(&document)
-        .map_err(|e| format!("failed to serialize GLTF JSON: {e}"))?;
+    let mut json_bytes =
+        serde_json::to_vec(&document).map_err(|e| format!("failed to serialize GLTF JSON: {e}"))?;
     pad_chunk(&mut json_bytes, 0x20); // ASCII space for JSON chunk
     pad_chunk(&mut bin, 0x00); // zeros for BIN chunk
 
@@ -2502,7 +2513,19 @@ mod tests {
     #[test]
     fn build_glb_roundtrips_a_unit_quad() {
         let mesh = unit_quad_split_into_two_triangles();
-        let glb = build_glb(&[], &[mesh], &default_materials(), &[], &[], &[], &[], &[], None, &[]).expect("build glb");
+        let glb = build_glb(
+            &[],
+            &[mesh],
+            &default_materials(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            &[],
+        )
+        .expect("build glb");
 
         // GLB header sanity check
         assert_eq!(&glb[0..4], b"glTF");
@@ -2512,8 +2535,7 @@ mod tests {
         assert_eq!(total_length as usize, glb.len());
 
         // First chunk should be JSON
-        let json_chunk_len =
-            u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        let json_chunk_len = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
         let json_chunk_type = u32::from_le_bytes(glb[16..20].try_into().unwrap());
         assert_eq!(json_chunk_type, CHUNK_TYPE_JSON);
         let json_start = 20;
@@ -2521,8 +2543,7 @@ mod tests {
         let json_text = std::str::from_utf8(&glb[json_start..json_end])
             .expect("json chunk is utf8")
             .trim_end_matches(' ');
-        let doc: serde_json::Value =
-            serde_json::from_str(json_text).expect("json chunk parses");
+        let doc: serde_json::Value = serde_json::from_str(json_text).expect("json chunk parses");
         assert_eq!(doc["asset"]["version"], "2.0");
         assert_eq!(doc["meshes"][0]["primitives"][0]["mode"], 4);
         assert_eq!(doc["accessors"].as_array().unwrap().len(), 4); // pos + normal + uv + idx
@@ -2531,11 +2552,15 @@ mod tests {
         // 4*3*4 (normals) + 4*2*4 (uvs) + 6*4 (indices) = 48 + 48 + 32 + 24 = 152
         // possibly padded.
         let bin_chunk_offset = json_end;
-        let bin_chunk_len =
-            u32::from_le_bytes(glb[bin_chunk_offset..bin_chunk_offset + 4].try_into().unwrap())
-                as usize;
+        let bin_chunk_len = u32::from_le_bytes(
+            glb[bin_chunk_offset..bin_chunk_offset + 4]
+                .try_into()
+                .unwrap(),
+        ) as usize;
         let bin_chunk_type = u32::from_le_bytes(
-            glb[bin_chunk_offset + 4..bin_chunk_offset + 8].try_into().unwrap(),
+            glb[bin_chunk_offset + 4..bin_chunk_offset + 8]
+                .try_into()
+                .unwrap(),
         );
         assert_eq!(bin_chunk_type, CHUNK_TYPE_BIN);
         assert!(bin_chunk_len >= 152, "bin chunk too small: {bin_chunk_len}");
@@ -2545,7 +2570,19 @@ mod tests {
     fn rejects_mismatched_normal_count() {
         let mut mesh = unit_quad_split_into_two_triangles();
         mesh.normals = Some(vec![0.0; 6]); // wrong length
-        let err = build_glb(&[], &[mesh], &default_materials(), &[], &[], &[], &[], &[], None, &[]).unwrap_err();
+        let err = build_glb(
+            &[],
+            &[mesh],
+            &default_materials(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            &[],
+        )
+        .unwrap_err();
         assert!(err.contains("normal"));
     }
 
@@ -2553,7 +2590,19 @@ mod tests {
     fn rejects_out_of_range_index() {
         let mut mesh = unit_quad_split_into_two_triangles();
         mesh.indices = vec![0, 1, 99];
-        let err = build_glb(&[], &[mesh], &default_materials(), &[], &[], &[], &[], &[], None, &[]).unwrap_err();
+        let err = build_glb(
+            &[],
+            &[mesh],
+            &default_materials(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            &[],
+        )
+        .unwrap_err();
         assert!(err.contains("out of range"));
     }
 
@@ -2561,7 +2610,19 @@ mod tests {
     fn rejects_material_index_out_of_range() {
         let mut mesh = unit_quad_split_into_two_triangles();
         mesh.material_index = 5;
-        let err = build_glb(&[], &[mesh], &default_materials(), &[], &[], &[], &[], &[], None, &[]).unwrap_err();
+        let err = build_glb(
+            &[],
+            &[mesh],
+            &default_materials(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            &[],
+        )
+        .unwrap_err();
         assert!(
             err.contains("material_index"),
             "expected material_index error, got: {err}"
@@ -2595,10 +2656,10 @@ mod tests {
             alpha_cutoff: 0.5,
             metallic_roughness_texture: None,
         }];
-        let glb = build_glb(&[], &[mesh], &materials, &[], &[], &[], &[], &[], None, &[]).expect("build glb");
+        let glb = build_glb(&[], &[mesh], &materials, &[], &[], &[], &[], &[], None, &[])
+            .expect("build glb");
 
-        let json_chunk_len =
-            u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        let json_chunk_len = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
         let json_start = 20;
         let json_end = json_start + json_chunk_len;
         let json_text = std::str::from_utf8(&glb[json_start..json_end])
@@ -2613,10 +2674,10 @@ mod tests {
     fn omits_alpha_mode_for_opaque_material() {
         let mesh = unit_quad_split_into_two_triangles();
         let materials = vec![MaterialInput::default_preview()];
-        let glb = build_glb(&[], &[mesh], &materials, &[], &[], &[], &[], &[], None, &[]).expect("build glb");
+        let glb = build_glb(&[], &[mesh], &materials, &[], &[], &[], &[], &[], None, &[])
+            .expect("build glb");
 
-        let json_chunk_len =
-            u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        let json_chunk_len = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
         let json_start = 20;
         let json_end = json_start + json_chunk_len;
         let json_text = std::str::from_utf8(&glb[json_start..json_end])
@@ -2681,11 +2742,22 @@ mod tests {
             },
         ];
 
-        let glb = build_glb(&[], &[red_mesh, blue_mesh], &materials, &[], &[], &[], &[], &[], None, &[]).expect("build glb");
+        let glb = build_glb(
+            &[],
+            &[red_mesh, blue_mesh],
+            &materials,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            &[],
+        )
+        .expect("build glb");
         assert_eq!(&glb[0..4], b"glTF");
 
-        let json_chunk_len =
-            u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        let json_chunk_len = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
         let json_start = 20;
         let json_end = json_start + json_chunk_len;
         let json_text = std::str::from_utf8(&glb[json_start..json_end])

--- a/src-tauri/src/usd/mod.rs
+++ b/src-tauri/src/usd/mod.rs
@@ -3,8 +3,8 @@
 //! Splits cleanly into:
 //!
 //! - [`types`] — wire-level types shared with the frontend.
-//! - [`backend`] — the [`backend::UsdBackend`] trait every parser
-//!   implementation must satisfy.
+//! - [`backend`] — capability traits every parser implementation can
+//!   implement independently.
 //! - [`openusd_backend`] — the pure-Rust adapter over our fork of
 //!   `mxpv/openusd`. Now opt-in via `backend-openusd-rs`; kept for
 //!   parity testing and for Linux targets where the C++ backend is
@@ -30,7 +30,10 @@ pub mod cpp_sys;
 #[cfg(feature = "backend-openusd-cpp")]
 pub mod openusd_cpp_backend;
 
-pub use backend::{UsdBackend, UsdError};
+pub use backend::{
+    UsdError, UsdGeometryBackend, UsdInspectBackend, UsdLightBackend, UsdSessionBackend,
+    UsdSourceBackend,
+};
 pub use openusd_backend::OpenusdBackend;
 pub use stage_state::{OpenSession, OpenStage, StageRegistry, StageSessionHandle};
 pub use types::{
@@ -77,10 +80,7 @@ pub use openusd_cpp_backend::OpenusdCppBackend;
 #[cfg(feature = "backend-openusd-cpp")]
 pub type DefaultBackend = OpenusdCppBackend;
 
-#[cfg(all(
-    feature = "backend-openusd-rs",
-    not(feature = "backend-openusd-cpp"),
-))]
+#[cfg(all(feature = "backend-openusd-rs", not(feature = "backend-openusd-cpp"),))]
 pub type DefaultBackend = OpenusdBackend;
 
 #[cfg(not(any(feature = "backend-openusd-rs", feature = "backend-openusd-cpp")))]

--- a/src-tauri/src/usd/openusd_backend.rs
+++ b/src-tauri/src/usd/openusd_backend.rs
@@ -15,12 +15,12 @@ use openusd::sdf::{Path as SdfPath, Value as SdfValue};
 use openusd::stage::{MaterialData, MeshData, UpAxis};
 use openusd::{Stage, StageLoadPolicy as OpenusdLoadPolicy};
 
-use super::backend::{UsdBackend, UsdError};
+use super::backend::{UsdGeometryBackend, UsdInspectBackend, UsdError};
 use super::glb::{self, MeshInput};
 use super::types::{
     AssetIssue, AssetIssueCode, AssetIssueLevel, AttributeTimeSamples, CompositionArc,
     CompositionArcKind, CompositionArcState, ExtractGeometryOptions, LayerInfo, PrimInspection,
-    PrimTypeCount, StageInspection, StageLoadPolicy, StageSummary, UsdLightInfo,
+    PrimTypeCount, StageInspection, StageLoadPolicy, StageSummary,
 };
 
 /// Translate the wire-level `StageLoadPolicy` used by Tauri commands
@@ -102,7 +102,7 @@ impl Default for OpenusdBackend {
     }
 }
 
-impl UsdBackend for OpenusdBackend {
+impl UsdInspectBackend for OpenusdBackend {
     fn inspect_stage(
         &self,
         path: &StdPath,
@@ -539,47 +539,6 @@ impl UsdBackend for OpenusdBackend {
         ))
     }
 
-    fn extract_geometry_glb(
-        &self,
-        path: &StdPath,
-        policy: StageLoadPolicy,
-    ) -> Result<Vec<u8>, UsdError> {
-        let stage = Self::open(path, policy)?;
-        extract_geometry_from_open_stage_rs(&stage, path, &ExtractGeometryOptions::from(policy))
-    }
-
-    fn extract_geometry_glb_with_options(
-        &self,
-        path: &StdPath,
-        options: &ExtractGeometryOptions,
-    ) -> Result<Vec<u8>, UsdError> {
-        if !options.variant_selections.is_empty() {
-            eprintln!(
-                "[usd-rust] extract_geometry_glb_with_options: variant_selections are \
-                 not supported by the Rust openusd backend (degraded mode). The \
-                 authored variant selections will be used instead."
-            );
-        }
-        let stage = Self::open(path, options.policy)?;
-        extract_geometry_from_open_stage_rs(&stage, path, options)
-    }
-
-    fn flatten_stage(&self, _path: &StdPath) -> Result<String, UsdError> {
-        Err(UsdError::Parse(
-            "flatten_stage is not supported on the Rust openusd backend; \
-             switch to the C++ backend (backend-openusd-cpp feature) to use this command"
-                .to_string(),
-        ))
-    }
-
-    fn inspect_usd_lights(&self, _path: &StdPath) -> Result<Vec<UsdLightInfo>, UsdError> {
-        Err(UsdError::Parse(
-            "inspect_usd_lights is not supported on the Rust openusd backend; \
-             switch to the C++ backend (backend-openusd-cpp feature) to use this command"
-                .to_string(),
-        ))
-    }
-
     fn collect_asset_issues(&self, path: &StdPath) -> Result<Vec<AssetIssue>, UsdError> {
         let stage = Self::open(path, StageLoadPolicy::LoadAll)?;
         let mut issues = Vec::new();
@@ -654,100 +613,32 @@ impl UsdBackend for OpenusdBackend {
 
         Ok(issues)
     }
+}
 
-    // ---- #44 session methods -----------------------------------------------
-
-    fn open_stage_session(
+impl UsdGeometryBackend for OpenusdBackend {
+    fn extract_geometry_glb(
         &self,
         path: &StdPath,
         policy: StageLoadPolicy,
-    ) -> Result<crate::usd::stage_state::OpenStage, UsdError> {
+    ) -> Result<Vec<u8>, UsdError> {
         let stage = Self::open(path, policy)?;
-        // `OpenStage::Rust` only exists when the Rust-fork backend feature is
-        // compiled in. When only `backend-openusd-cpp` is enabled, this code
-        // path is unreachable because `DefaultBackend` resolves to
-        // `OpenusdCppBackend` — `OpenusdBackend` is never instantiated.
-        #[cfg(feature = "backend-openusd-rs")]
-        return Ok(crate::usd::stage_state::OpenStage::Rust(
-            std::sync::Mutex::new(stage),
-        ));
-        #[cfg(not(feature = "backend-openusd-rs"))]
-        {
-            drop(stage);
-            unreachable!(
-                "OpenusdBackend::open_stage_session called without backend-openusd-rs feature"
+        extract_geometry_from_open_stage_rs(&stage, path, &ExtractGeometryOptions::from(policy))
+    }
+
+    fn extract_geometry_glb_with_options(
+        &self,
+        path: &StdPath,
+        options: &ExtractGeometryOptions,
+    ) -> Result<Vec<u8>, UsdError> {
+        if !options.variant_selections.is_empty() {
+            eprintln!(
+                "[usd-rust] extract_geometry_glb_with_options: variant_selections are \
+                 not supported by the Rust openusd backend (degraded mode). The \
+                 authored variant selections will be used instead."
             );
         }
-    }
-
-    fn load_payload(
-        &self,
-        _stage: &crate::usd::stage_state::OpenStage,
-        _prim_path: &str,
-    ) -> Result<(), UsdError> {
-        Err(UsdError::Parse(
-            "per-prim payload load is not supported on the Rust openusd backend; \
-             switch to the C++ backend (backend-openusd-cpp feature)"
-                .to_string(),
-        ))
-    }
-
-    fn unload_payload(
-        &self,
-        _stage: &crate::usd::stage_state::OpenStage,
-        _prim_path: &str,
-    ) -> Result<(), UsdError> {
-        Err(UsdError::Parse(
-            "per-prim payload unload is not supported on the Rust openusd backend; \
-             switch to the C++ backend (backend-openusd-cpp feature)"
-                .to_string(),
-        ))
-    }
-
-    fn extract_geometry_from_session(
-        &self,
-        stage: &crate::usd::stage_state::OpenStage,
-        #[cfg(feature = "backend-openusd-rs")] stage_path: &StdPath,
-        #[cfg(not(feature = "backend-openusd-rs"))] _stage_path: &StdPath,
-        #[cfg(feature = "backend-openusd-rs")] options: &ExtractGeometryOptions,
-        #[cfg(not(feature = "backend-openusd-rs"))] _options: &ExtractGeometryOptions,
-    ) -> Result<Vec<u8>, UsdError> {
-        // Dispatch based on which OpenStage variant is actually compiled in.
-        // Only one variant exists per feature combination, so we match with
-        // exhaustive arms guarded by cfg.
-        #[cfg(all(feature = "backend-openusd-rs", not(feature = "backend-openusd-cpp")))]
-        {
-            let crate::usd::stage_state::OpenStage::Rust(mutex) = stage;
-            let locked = mutex
-                .lock()
-                .map_err(|_| UsdError::Parse("stage Mutex was poisoned".to_string()))?;
-            return extract_geometry_from_open_stage_rs(&locked, stage_path, options);
-        }
-        #[cfg(all(feature = "backend-openusd-rs", feature = "backend-openusd-cpp"))]
-        match stage {
-            crate::usd::stage_state::OpenStage::Rust(mutex) => {
-                let locked = mutex
-                    .lock()
-                    .map_err(|_| UsdError::Parse("stage Mutex was poisoned".to_string()))?;
-                return extract_geometry_from_open_stage_rs(&locked, stage_path, options);
-            }
-            crate::usd::stage_state::OpenStage::Cpp(_) => {
-                return Err(UsdError::Parse(
-                    "extract_geometry_from_session: Cpp stage handle passed to Rust backend"
-                        .to_string(),
-                ));
-            }
-        }
-        // When only the C++ backend is compiled in, the Rust variant does not
-        // exist — this arm is unreachable but required for exhaustiveness.
-        #[cfg(not(feature = "backend-openusd-rs"))]
-        {
-            let _ = stage;
-            Err(UsdError::Parse(
-                "extract_geometry_from_session: Cpp stage handle passed to Rust backend"
-                    .to_string(),
-            ))
-        }
+        let stage = Self::open(path, options.policy)?;
+        extract_geometry_from_open_stage_rs(&stage, path, options)
     }
 }
 

--- a/src-tauri/src/usd/openusd_cpp_backend.rs
+++ b/src-tauri/src/usd/openusd_cpp_backend.rs
@@ -25,7 +25,10 @@ use std::path::Path as StdPath;
 use openusd::sdf::Path as SdfPath;
 use openusd::stage::MeshData;
 
-use super::backend::{UsdBackend, UsdError};
+use super::backend::{
+    UsdGeometryBackend, UsdInspectBackend, UsdLightBackend, UsdSessionBackend, UsdSourceBackend,
+    UsdError,
+};
 use super::cpp_sys::{CStage, Interpolation, LoadPolicy, Orientation};
 use super::glb::{self, AlphaMode, InstancingInput, MaterialInput, MeshInput};
 use super::openusd_backend::DenseBlendShape;
@@ -106,7 +109,7 @@ fn classify_payload(
     CompositionArcState::Loaded
 }
 
-impl UsdBackend for OpenusdCppBackend {
+impl UsdInspectBackend for OpenusdCppBackend {
     fn inspect_stage(
         &self,
         path: &StdPath,
@@ -652,6 +655,9 @@ impl UsdBackend for OpenusdCppBackend {
         })
     }
 
+}
+
+impl UsdGeometryBackend for OpenusdCppBackend {
     fn extract_geometry_glb(
         &self,
         path: &StdPath,
@@ -692,6 +698,9 @@ impl UsdBackend for OpenusdCppBackend {
         extract_from_stage(&stage, path)
     }
 
+}
+
+impl UsdSourceBackend for OpenusdCppBackend {
     fn flatten_stage(&self, path: &StdPath) -> Result<String, UsdError> {
         // Use LoadAll so every composition arc is included in the
         // flattened output, matching `usdcat --flatten` semantics.
@@ -704,6 +713,9 @@ impl UsdBackend for OpenusdCppBackend {
         })
     }
 
+}
+
+impl UsdLightBackend for OpenusdCppBackend {
     fn inspect_usd_lights(&self, path: &StdPath) -> Result<Vec<UsdLightInfo>, UsdError> {
         let stage = Self::open(path, StageLoadPolicy::LoadAll)?;
         let lights = stage.lights();
@@ -728,6 +740,9 @@ impl UsdBackend for OpenusdCppBackend {
         Ok(result)
     }
 
+}
+
+impl UsdSessionBackend for OpenusdCppBackend {
     // ---- #44 session methods -----------------------------------------------
 
     fn open_stage_session(

--- a/src-tauri/tests/cpp_backend_geometry.rs
+++ b/src-tauri/tests/cpp_backend_geometry.rs
@@ -12,7 +12,7 @@
 
 use std::path::PathBuf;
 
-use yw_look_lib::usd::{OpenusdCppBackend, StageLoadPolicy, UsdBackend};
+use yw_look_lib::usd::{OpenusdCppBackend, StageLoadPolicy, UsdGeometryBackend};
 
 /// Fixture resolver shared with `cpp_backend_inspector.rs`.
 fn tiny_usda_path() -> PathBuf {

--- a/src-tauri/tests/cpp_backend_inspector.rs
+++ b/src-tauri/tests/cpp_backend_inspector.rs
@@ -23,7 +23,7 @@
 
 use std::path::PathBuf;
 
-use yw_look_lib::usd::{OpenusdCppBackend, StageLoadPolicy, UsdBackend};
+use yw_look_lib::usd::{OpenusdCppBackend, StageLoadPolicy, UsdInspectBackend, UsdSourceBackend};
 
 /// Resolve the Phase 0 tiny fixture relative to the cargo manifest so
 /// `cargo test` works regardless of the current working directory that

--- a/src-tauri/tests/cpp_backend_payload_session.rs
+++ b/src-tauri/tests/cpp_backend_payload_session.rs
@@ -16,7 +16,7 @@
 use std::path::PathBuf;
 
 use yw_look_lib::usd::{
-    stage_state::OpenStage, OpenusdCppBackend, StageLoadPolicy, UsdBackend,
+    stage_state::OpenStage, OpenusdCppBackend, StageLoadPolicy, UsdSessionBackend,
 };
 
 fn tiny_payload_path() -> PathBuf {

--- a/src-tauri/tests/cpp_backend_point_instancer.rs
+++ b/src-tauri/tests/cpp_backend_point_instancer.rs
@@ -14,7 +14,7 @@
 
 use std::path::PathBuf;
 
-use yw_look_lib::usd::{OpenusdCppBackend, StageLoadPolicy, UsdBackend};
+use yw_look_lib::usd::{OpenusdCppBackend, StageLoadPolicy, UsdGeometryBackend};
 
 fn tiny_point_instancer_path() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");

--- a/src/lib/usd.ts
+++ b/src/lib/usd.ts
@@ -10,6 +10,14 @@ import { readBinaryFile } from "./files";
  */
 export type StageLoadPolicy = "loadAll" | "noPayloads";
 
+export type BackendCapabilities = {
+  inspect: boolean;
+  geometry: boolean;
+  source: boolean;
+  session: boolean;
+  light: boolean;
+};
+
 /**
  * Resolution state of a composition arc.
  * - `loaded`: the arc is composed into the stage.
@@ -469,6 +477,10 @@ export async function loadUsdSource(
   const buffer = Uint8Array.from(bytes).buffer;
   const text = await tryExtractUsdaText(extension, buffer);
   return text === null ? { kind: "binary" } : { kind: "text", source: text };
+}
+
+export async function backendCapabilities(): Promise<BackendCapabilities> {
+  return invoke<BackendCapabilities>("backendCapabilities");
 }
 
 /**


### PR DESCRIPTION
Closes #55

## Summary
- 単一 `UsdBackend` trait を 5 つの capability trait (`UsdInspectBackend` / `UsdGeometryBackend` / `UsdSourceBackend` / `UsdSessionBackend` / `UsdLightBackend`) に分割
- backend が一部だけ実装すれば動くようにし、Rust fork backend (yohawing/openusd) は inspect + geometry のみ、C++ backend は 5 capability すべてを実装
- Tauri state を capability 別に保持し、`backendCapabilities` Tauri command + frontend helper を追加
- 既存 Tauri command 名 / 引数は維持し frontend 差分を最小化

## Changes
- src-tauri/src/usd/backend.rs — trait 5 分割 + 既存 `UsdBackend` を deprecated supertrait alias 相当に
- src-tauri/src/usd/openusd_backend.rs — Rust backend を inspect+geometry のみ実装に再編
- src-tauri/src/usd/openusd_cpp_backend.rs — C++ backend で 5 capability を網羅
- src-tauri/src/usd/mod.rs — re-export 整理
- src-tauri/src/lib.rs — Tauri state を capability 別 `Option<Arc<dyn ...>>` に変更、`backendCapabilities` command を追加、不在時は typed error 相当の文字列で reject
- src-tauri/src/bin/usd_to_glb.rs — geometry trait のみ要求するよう型を絞る
- src/lib/usd.ts — `BackendCapabilities` 型と `backendCapabilities()` helper 追加
- src-tauri/tests/cpp_backend_*.rs — trait import を新 capability trait に追従

## Verification
- cargo test --no-default-features --features backend-openusd-rs: 42 passed, 25 ignored
- pnpm tsc --noEmit / pnpm lint: codex sandbox の `node_modules` 不在で未実行 (CI / 開発機での再確認推奨)
- 既定 C++ backend の build / clippy: ローカル `VCPKG_ROOT` 未設定で未実行 (CI 確認推奨)

## Note on diff size
- `cpp_sys/mod.rs` (259 行) と `glb.rs` (158 行) は trait 分割そのものではなく rustfmt 由来のブロック整形 churn を含みます (codex が暗黙的に整形)
- 機能差分は backend.rs / openusd_*_backend.rs / lib.rs / mod.rs / usd.ts に集約されており、diff としては大きく見えますが意味のある変更は限定的
- レビュー時は backend.rs と lib.rs の diff を中心に確認してください

## Self-Review (Codex)
信頼度: 中
- 5 trait 分割、capability 別 state、`backendCapabilities` command / TS helper は実装済み
- `stage_state.rs` (#56) / FFI 層 (#57) / variant typed error (#58) の領域には踏み込んでいない
- Rust backend の source/light/session capability は false、対応 command は早期 error で reject
- 既存 command 名・引数は維持
- 残課題: Codex review と Node 側 typecheck/lint を環境ありで再実行