### PR TITLE
feat(shortcut): add view/selection/visibility/display shortcuts (#51)

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -368,6 +368,7 @@ USD-view パリティの取り組みは tracking issue #27 配下で進める。
 - [x] `F11` — フルスクリーン切替を実装する
 - [x] 各表示モードのショートカットを割り当てる
 - [x] メニュー項目にショートカット表記を表示する
+- [x] #51: View / Selection / Visibility / Display 優先の単キーショートカットを整理する
 
 ### Settings 導線
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,14 @@ import {
   type MenuActionId,
 } from "./lib/menu";
 import {
+  applyViewerShortcutAction,
+  isEditableShortcutTarget,
+  resolveViewerShortcutAction,
+  viewerShortcutHelpLines,
+  type ViewportShortcutCommand,
+  type ViewerShortcutAction,
+} from "./lib/viewerShortcuts";
+import {
   checkForUpdate,
   installPendingUpdate,
   loadUpdateConfiguration,
@@ -294,6 +302,8 @@ export function App() {
   const [openError, setOpenError] = useState<string | null>(null);
   const [isDragActive, setIsDragActive] = useState(false);
   const [resetVersion, setResetVersion] = useState(0);
+  const [viewportShortcutCommand, setViewportShortcutCommand] =
+    useState<ViewportShortcutCommand | null>(null);
   const [settingsPayload, setSettingsPayload] =
     useState<SettingsPayload | null>(null);
   const [settingsError, setSettingsError] = useState<string | null>(null);
@@ -506,11 +516,13 @@ export function App() {
   }, [assetMetadata?.textures, usdIssues, viewerFeedback.warning]);
   const sidebarWarnings = debugPanelsEnabled ? debugPanelWarnings : warnings;
   const shortcutLines = useMemo(
-    () =>
-      Object.entries(menuShortcuts).map(([actionId, definition]) => {
+    () => [
+      ...viewerShortcutHelpLines,
+      ...Object.entries(menuShortcuts).map(([actionId, definition]) => {
         const actionLabel = actionId.split(".").join(" > ");
         return `${formatShortcut(definition)}  ${actionLabel}`;
       }),
+    ],
     [],
   );
 
@@ -1341,19 +1353,30 @@ export function App() {
     };
   }, [canNavigateNext, canNavigatePrev, directoryListing]);
 
-  // #33: Esc key clears the active mesh selection.
   useEffect(() => {
-    if (!selectedMeshName) return;
-    const handleEscKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setSelectedMeshName(null);
+    const handleViewerShortcutDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
       }
+
+      if (isEditableShortcutTarget(event.target)) {
+        return;
+      }
+
+      const action = resolveViewerShortcutAction(event);
+      if (!action) {
+        return;
+      }
+
+      event.preventDefault();
+      runViewerShortcutAction(action);
     };
-    window.addEventListener("keydown", handleEscKey);
+
+    window.addEventListener("keydown", handleViewerShortcutDown);
     return () => {
-      window.removeEventListener("keydown", handleEscKey);
+      window.removeEventListener("keydown", handleViewerShortcutDown);
     };
-  }, [selectedMeshName]);
+  }, []);
 
   const handleOpenFile = async () => {
     try {
@@ -1478,9 +1501,57 @@ export function App() {
         return;
     }
   };
+
+  const executeViewerShortcutAction = (action: ViewerShortcutAction) => {
+    if (
+      action === "focusSelected" ||
+      action === "frameAll" ||
+      action === "resetView"
+    ) {
+      setActiveCameraId(null);
+    }
+
+    const nextState = applyViewerShortcutAction(
+      {
+        showTexture,
+        showWireframe,
+        showGrid,
+        selectedMeshName,
+        selectedUsdPrimPath,
+        viewportCommand: viewportShortcutCommand,
+      },
+      action,
+      displayMode,
+    );
+
+    if (nextState.showTexture !== showTexture) {
+      setShowTexture(nextState.showTexture);
+    }
+    if (nextState.showWireframe !== showWireframe) {
+      setShowWireframe(nextState.showWireframe);
+    }
+    if (nextState.showGrid !== showGrid) {
+      setShowGrid(nextState.showGrid);
+    }
+    if (nextState.selectedMeshName !== selectedMeshName) {
+      setSelectedMeshName(nextState.selectedMeshName);
+    }
+    if (nextState.selectedUsdPrimPath !== selectedUsdPrimPath) {
+      setSelectedUsdPrimPath(nextState.selectedUsdPrimPath);
+    }
+    if (nextState.viewportCommand !== viewportShortcutCommand) {
+      setViewportShortcutCommand(nextState.viewportCommand);
+    }
+  };
+
   const runMenuActionFromShortcut = useEffectEvent((actionId: MenuActionId) => {
     void executeMenuAction(actionId);
   });
+  const runViewerShortcutAction = useEffectEvent(
+    (action: ViewerShortcutAction) => {
+      executeViewerShortcutAction(action);
+    },
+  );
   const runMenuActionFromNativeMenu = useEffectEvent(
     (actionId: MenuActionId) => {
       void executeMenuAction(actionId);
@@ -1525,12 +1596,7 @@ export function App() {
         return;
       }
 
-      const target = event.target as HTMLElement | null;
-      const isTyping =
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLTextAreaElement ||
-        target?.isContentEditable;
-      if (isTyping) {
+      if (isEditableShortcutTarget(event.target)) {
         return;
       }
 
@@ -2091,6 +2157,7 @@ export function App() {
             textureTileCount={textureTileCount}
             textureGamma={textureGamma}
             resetVersion={resetVersion}
+            viewportShortcutCommand={viewportShortcutCommand}
             showGrid={showGrid}
             showAxes={showAxes}
             showSkeleton={showSkeleton}

--- a/src/components/AssetViewport.tsx
+++ b/src/components/AssetViewport.tsx
@@ -4,6 +4,7 @@ import {
   AmbientLight,
   AnimationMixer,
   BackSide,
+  Box3,
   BoxGeometry,
   Camera,
   Color,
@@ -31,6 +32,7 @@ import {
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import type { SelectedFile } from "../lib/files";
+import type { ViewportShortcutCommand } from "../lib/viewerShortcuts";
 import {
   type CameraPreset,
   type DisplayMode,
@@ -223,6 +225,90 @@ function frameMountedObject(
   context.controls.enabled = true;
 }
 
+function selectionKeyForObject(object: Object3D) {
+  const primPath =
+    typeof object.userData?.primPath === "string"
+      ? object.userData.primPath
+      : undefined;
+  const raw = typeof object.name === "string" ? object.name.trim() : "";
+  return primPath ?? (raw.length > 0 ? raw : null);
+}
+
+function findObjectBySelectionKey(root: Object3D, selectionKey: string) {
+  let match: Object3D | null = null;
+
+  root.traverse((child) => {
+    if (match) return;
+    if (selectionKeyForObject(child) === selectionKey) {
+      match = child;
+    }
+  });
+
+  return match;
+}
+
+function frameObjectBounds(
+  context: SceneContext,
+  object: Object3D,
+  sensitivityMultiplier = 1,
+) {
+  const bounds = new Box3().setFromObject(object);
+  if (bounds.isEmpty()) {
+    return;
+  }
+
+  const size = bounds.getSize(new Vector3());
+  const center = bounds.getCenter(new Vector3());
+  const maxDimension = Math.max(size.x, size.y, size.z, 0.001);
+  const fitHeightDistance =
+    maxDimension /
+    (2 * Math.tan(MathUtils.degToRad(context.camera.fov * 0.5)));
+  const fitDistance = fitHeightDistance * 1.5;
+  const direction = context.camera.position
+    .clone()
+    .sub(context.controls.target)
+    .normalize();
+  if (direction.lengthSq() === 0) {
+    direction.set(1.15, 0.8, 1.15).normalize();
+  }
+
+  context.camera.position.copy(
+    center.clone().add(direction.multiplyScalar(fitDistance)),
+  );
+  context.camera.near = Math.max(maxDimension / 500, 0.01);
+  context.camera.far = Math.max(maxDimension * 20, 200);
+  context.camera.lookAt(center);
+  context.camera.updateProjectionMatrix();
+
+  context.controls.target.copy(center);
+  context.controls.minDistance = Math.max(maxDimension / 50, 0.05);
+  context.controls.maxDistance = Math.max(maxDimension * 40, 50);
+  applyControlsSensitivity(context.controls, maxDimension, sensitivityMultiplier);
+  context.controls.update();
+  context.controls.enabled = true;
+}
+
+function setSubtreeVisible(root: Object3D, visible: boolean) {
+  root.traverse((child) => {
+    if (child.name === "__yw_shadow_catcher") {
+      return;
+    }
+    child.visible = visible;
+  });
+}
+
+function isolateObject(root: Object3D, selected: Object3D) {
+  setSubtreeVisible(root, false);
+  setSubtreeVisible(selected, true);
+
+  let ancestor = selected.parent;
+  while (ancestor && ancestor !== root.parent) {
+    ancestor.visible = true;
+    if (ancestor === root) break;
+    ancestor = ancestor.parent;
+  }
+}
+
 type AssetViewportProps = {
   currentFile: SelectedFile | null;
   displayMode: DisplayMode;
@@ -238,6 +324,7 @@ type AssetViewportProps = {
   textureTileCount: number;
   textureGamma: number;
   resetVersion: number;
+  viewportShortcutCommand?: ViewportShortcutCommand | null;
   showGrid: boolean;
   showAxes: boolean;
   showSkeleton: boolean;
@@ -506,6 +593,7 @@ export function AssetViewport({
   textureTileCount,
   textureGamma,
   resetVersion,
+  viewportShortcutCommand,
   showGrid,
   showAxes,
   showSkeleton,
@@ -2244,6 +2332,90 @@ export function AssetViewport({
   useEffect(() => {
     resetCameraRef.current?.();
   }, [resetVersion]);
+
+  useEffect(() => {
+    if (!viewportShortcutCommand) {
+      return;
+    }
+
+    const context = sceneContextRef.current;
+    if (!context) {
+      return;
+    }
+
+    const mountedObject = context.mountedObject;
+    const sourceObject = context.sourceObject;
+
+    switch (viewportShortcutCommand.kind) {
+      case "focusSelected": {
+        if (!sourceObject || viewerSurfaceModeRef.current !== "asset") {
+          return;
+        }
+        const target = findObjectBySelectionKey(
+          sourceObject,
+          viewportShortcutCommand.selectionKey,
+        );
+        if (target) {
+          configureAssetControls(context.controls);
+          frameObjectBounds(
+            context,
+            target,
+            cameraSpeedMultiplierRef.current,
+          );
+        }
+        return;
+      }
+      case "frameAll":
+      case "resetView":
+        if (!mountedObject) {
+          return;
+        }
+        frameMountedObject(
+          context,
+          mountedObject,
+          viewerSurfaceModeRef.current,
+          showGridRef.current,
+          showAxesRef.current,
+          cameraSpeedMultiplierRef.current,
+          context.rawMaxDimension,
+          texturePreview3DRef.current,
+        );
+        return;
+      case "hideSelected": {
+        if (!sourceObject || viewerSurfaceModeRef.current !== "asset") {
+          return;
+        }
+        const target = findObjectBySelectionKey(
+          sourceObject,
+          viewportShortcutCommand.selectionKey,
+        );
+        if (target) {
+          target.visible = false;
+        }
+        return;
+      }
+      case "isolateSelected": {
+        if (!sourceObject || viewerSurfaceModeRef.current !== "asset") {
+          return;
+        }
+        const target = findObjectBySelectionKey(
+          sourceObject,
+          viewportShortcutCommand.selectionKey,
+        );
+        if (target) {
+          isolateObject(sourceObject, target);
+        }
+        return;
+      }
+      case "unhideAll":
+        if (!sourceObject || viewerSurfaceModeRef.current !== "asset") {
+          return;
+        }
+        setSubtreeVisible(sourceObject, true);
+        applyPurposeVisibility(sourceObject, purposeModesRef.current);
+        return;
+    }
+  }, [viewportShortcutCommand]);
 
   useEffect(() => {
     if (!cameraPresetRequest) {

--- a/src/lib/__tests__/viewerShortcuts.test.ts
+++ b/src/lib/__tests__/viewerShortcuts.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyViewerShortcutAction,
+  isEditableShortcutTarget,
+  resolveViewerShortcutAction,
+  type ViewerShortcutState,
+} from "../viewerShortcuts";
+import type { DisplayMode } from "../../viewer";
+
+function event(
+  key: string,
+  modifiers: Partial<KeyboardEvent> = {},
+): Pick<
+  KeyboardEvent,
+  "key" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+> {
+  return {
+    key,
+    altKey: Boolean(modifiers.altKey),
+    ctrlKey: Boolean(modifiers.ctrlKey),
+    metaKey: Boolean(modifiers.metaKey),
+    shiftKey: Boolean(modifiers.shiftKey),
+  };
+}
+
+function baseState(
+  overrides: Partial<ViewerShortcutState> = {},
+): ViewerShortcutState {
+  return {
+    showTexture: true,
+    showWireframe: false,
+    showGrid: true,
+    selectedMeshName: "/World/Cube",
+    selectedUsdPrimPath: "/World/Cube",
+    viewportCommand: null,
+    ...overrides,
+  };
+}
+
+function applyKey(
+  key: string,
+  displayMode: DisplayMode = "textured",
+  state = baseState(),
+  modifiers: Partial<KeyboardEvent> = {},
+) {
+  const action = resolveViewerShortcutAction(event(key, modifiers));
+  if (!action) {
+    throw new Error(`Expected ${key} to resolve to a viewer shortcut action.`);
+  }
+  return applyViewerShortcutAction(state, action, displayMode);
+}
+
+describe("viewer shortcuts", () => {
+  it("maps F to focus selected", () => {
+    const next = applyKey("f");
+    expect(next.viewportCommand).toMatchObject({
+      kind: "focusSelected",
+      selectionKey: "/World/Cube",
+      version: 1,
+    });
+  });
+
+  it("maps Home to frame all", () => {
+    const next = applyKey("Home");
+    expect(next.viewportCommand).toMatchObject({
+      kind: "frameAll",
+      version: 1,
+    });
+  });
+
+  it("maps R to reset view", () => {
+    const next = applyKey("r");
+    expect(next.viewportCommand).toMatchObject({
+      kind: "resetView",
+      version: 1,
+    });
+  });
+
+  it("maps Esc to clear selection", () => {
+    const next = applyKey("Escape");
+    expect(next.selectedMeshName).toBeNull();
+    expect(next.selectedUsdPrimPath).toBeNull();
+  });
+
+  it("maps H to hide selected", () => {
+    const next = applyKey("h");
+    expect(next.viewportCommand).toMatchObject({
+      kind: "hideSelected",
+      selectionKey: "/World/Cube",
+      version: 1,
+    });
+  });
+
+  it("maps Shift+H to isolate selected", () => {
+    const next = applyKey("h", "textured", baseState(), { shiftKey: true });
+    expect(next.viewportCommand).toMatchObject({
+      kind: "isolateSelected",
+      selectionKey: "/World/Cube",
+      version: 1,
+    });
+  });
+
+  it("maps Alt+H to unhide all", () => {
+    const next = applyKey("h", "textured", baseState(), { altKey: true });
+    expect(next.viewportCommand).toMatchObject({
+      kind: "unhideAll",
+      version: 1,
+    });
+  });
+
+  it("maps Z to cycle display mode", () => {
+    const next = applyKey("z");
+    expect(next.showTexture).toBe(false);
+    expect(next.showWireframe).toBe(false);
+  });
+
+  it("maps G to toggle grid", () => {
+    const next = applyKey("g");
+    expect(next.showGrid).toBe(false);
+  });
+
+  it("ignores editable shortcut targets", () => {
+    expect(isEditableShortcutTarget(document.createElement("input"))).toBe(
+      true,
+    );
+    expect(isEditableShortcutTarget(document.createElement("textarea"))).toBe(
+      true,
+    );
+
+    const editable = document.createElement("div");
+    editable.contentEditable = "true";
+    expect(isEditableShortcutTarget(editable)).toBe(true);
+  });
+
+  it("does not steal modified editing shortcuts", () => {
+    expect(resolveViewerShortcutAction(event("f", { ctrlKey: true }))).toBe(
+      null,
+    );
+    expect(resolveViewerShortcutAction(event("z", { metaKey: true }))).toBe(
+      null,
+    );
+  });
+});

--- a/src/lib/viewerShortcuts.ts
+++ b/src/lib/viewerShortcuts.ts
@@ -1,0 +1,224 @@
+import type { DisplayMode } from "../viewer";
+
+export type ViewerShortcutAction =
+  | "focusSelected"
+  | "frameAll"
+  | "resetView"
+  | "clearSelection"
+  | "hideSelected"
+  | "isolateSelected"
+  | "unhideAll"
+  | "cycleDisplayMode"
+  | "toggleGrid";
+
+export type ViewportShortcutCommand =
+  | { kind: "focusSelected"; selectionKey: string; version: number }
+  | { kind: "frameAll"; version: number }
+  | { kind: "resetView"; version: number }
+  | { kind: "hideSelected"; selectionKey: string; version: number }
+  | { kind: "isolateSelected"; selectionKey: string; version: number }
+  | { kind: "unhideAll"; version: number };
+
+export type ViewerShortcutState = {
+  showTexture: boolean;
+  showWireframe: boolean;
+  showGrid: boolean;
+  selectedMeshName: string | null;
+  selectedUsdPrimPath: string | null;
+  viewportCommand: ViewportShortcutCommand | null;
+};
+
+export const viewerShortcutHelpLines = [
+  "F  View > Focus selected",
+  "Home  View > Frame all",
+  "R  View > Reset view",
+  "Esc  Selection > Clear selection",
+  "H  Visibility > Hide selected",
+  "Shift+H  Visibility > Isolate selected",
+  "Alt+H  Visibility > Unhide all",
+  "Z  Display > Cycle display mode",
+  "G  Display > Toggle grid",
+];
+
+type KeyboardShortcutEvent = Pick<
+  KeyboardEvent,
+  "key" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
+const displayModeCycle: DisplayMode[] = [
+  "textured",
+  "untextured",
+  "wireframe",
+  "texturedWireframe",
+];
+
+function shortcutKey(event: KeyboardShortcutEvent) {
+  const key = event.key.toLowerCase();
+  return key === "esc" ? "escape" : key;
+}
+
+function hasOnlyModifiers(
+  event: KeyboardShortcutEvent,
+  modifiers: { alt?: boolean; shift?: boolean } = {},
+) {
+  return (
+    !event.ctrlKey &&
+    !event.metaKey &&
+    event.altKey === Boolean(modifiers.alt) &&
+    event.shiftKey === Boolean(modifiers.shift)
+  );
+}
+
+export function isEditableShortcutTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const contentEditableHost = target.closest(
+    "[contenteditable=''], [contenteditable='true']",
+  );
+
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target.isContentEditable ||
+    contentEditableHost !== null
+  );
+}
+
+export function resolveViewerShortcutAction(
+  event: KeyboardShortcutEvent,
+): ViewerShortcutAction | null {
+  const key = shortcutKey(event);
+
+  if (key === "h" && hasOnlyModifiers(event, { shift: true })) {
+    return "isolateSelected";
+  }
+
+  if (key === "h" && hasOnlyModifiers(event, { alt: true })) {
+    return "unhideAll";
+  }
+
+  if (!hasOnlyModifiers(event)) {
+    return null;
+  }
+
+  switch (key) {
+    case "f":
+      return "focusSelected";
+    case "home":
+      return "frameAll";
+    case "r":
+      return "resetView";
+    case "escape":
+      return "clearSelection";
+    case "h":
+      return "hideSelected";
+    case "z":
+      return "cycleDisplayMode";
+    case "g":
+      return "toggleGrid";
+    default:
+      return null;
+  }
+}
+
+export function deriveDisplayFlags(displayMode: DisplayMode) {
+  return {
+    showTexture:
+      displayMode === "textured" || displayMode === "texturedWireframe",
+    showWireframe:
+      displayMode === "wireframe" || displayMode === "texturedWireframe",
+  };
+}
+
+export function cycleDisplayMode(current: DisplayMode): DisplayMode {
+  const index = displayModeCycle.indexOf(current);
+  return displayModeCycle[(index + 1) % displayModeCycle.length] ?? "textured";
+}
+
+function nextCommandVersion(command: ViewportShortcutCommand | null) {
+  return (command?.version ?? 0) + 1;
+}
+
+export function applyViewerShortcutAction(
+  state: ViewerShortcutState,
+  action: ViewerShortcutAction,
+  displayMode: DisplayMode,
+): ViewerShortcutState {
+  switch (action) {
+    case "focusSelected":
+      if (!state.selectedMeshName) return state;
+      return {
+        ...state,
+        viewportCommand: {
+          kind: "focusSelected",
+          selectionKey: state.selectedMeshName,
+          version: nextCommandVersion(state.viewportCommand),
+        },
+      };
+    case "frameAll":
+      return {
+        ...state,
+        viewportCommand: {
+          kind: "frameAll",
+          version: nextCommandVersion(state.viewportCommand),
+        },
+      };
+    case "resetView":
+      return {
+        ...state,
+        viewportCommand: {
+          kind: "resetView",
+          version: nextCommandVersion(state.viewportCommand),
+        },
+      };
+    case "clearSelection":
+      return {
+        ...state,
+        selectedMeshName: null,
+        selectedUsdPrimPath: null,
+      };
+    case "hideSelected":
+      if (!state.selectedMeshName) return state;
+      return {
+        ...state,
+        viewportCommand: {
+          kind: "hideSelected",
+          selectionKey: state.selectedMeshName,
+          version: nextCommandVersion(state.viewportCommand),
+        },
+      };
+    case "isolateSelected":
+      if (!state.selectedMeshName) return state;
+      return {
+        ...state,
+        viewportCommand: {
+          kind: "isolateSelected",
+          selectionKey: state.selectedMeshName,
+          version: nextCommandVersion(state.viewportCommand),
+        },
+      };
+    case "unhideAll":
+      return {
+        ...state,
+        viewportCommand: {
+          kind: "unhideAll",
+          version: nextCommandVersion(state.viewportCommand),
+        },
+      };
+    case "cycleDisplayMode": {
+      const next = deriveDisplayFlags(cycleDisplayMode(displayMode));
+      return {
+        ...state,
+        showTexture: next.showTexture,
+        showWireframe: next.showWireframe,
+      };
+    }
+    case "toggleGrid":
+      return {
+        ...state,
+        showGrid: !state.showGrid,
+      };
+  }
+}


### PR DESCRIPTION
Closes #51

## Summary
yw-look は viewer なので、編集系より **View / Selection / Visibility / Display** を優先する単キーショートカットを追加。Blender / Maya 慣例に寄せた割り当て。

| キー | 動作 | カテゴリ |
|---|---|---|
| F | Focus selected | View |
| Home | Frame all | View |
| R | Reset view | View |
| Esc | Clear selection | Selection |
| H | Hide selected | Visibility |
| Shift+H | Isolate selected | Visibility |
| Alt+H | Unhide all | Visibility |
| Z | Display mode (cycle) | Display |
| G | Grid toggle | Display |

## Changes
- `src/lib/viewerShortcuts.ts` (new) — shortcut 解決、editable target guard、display mode cycle、shortcut help lines
- `src/lib/__tests__/viewerShortcuts.test.ts` (new) — 9 キー + editable guard + modifier collision の unit test
- `src/App.tsx` — global keydown handler 追加、selection clear / display / grid state 操作、viewport command dispatch、shortcut help 表示
- `src/components/AssetViewport.tsx` — focus selected / frame all / reset view / hide selected / isolate selected / unhide all の Three.js scene 実行
- `ToDo.md` — #51 項目追加

## Notes
- 既存の menu shortcut (Ctrl/Meta 系) と分離。modifier 付きは menu 側に残す
- input / textarea / contenteditable focus 中はガードで非発火
- 選択無し時の `F` / `H` / `Shift+H` は no-op
- `Alt+H` は scene visibility を戻した後に USD purpose visibility を再適用
- texture viewer 中の visibility 操作は no-op
- active USD camera 中の View shortcut は free orbit に戻してから動かす

## Verification
- pnpm vitest / tsc / eslint: codex sandbox の `node_modules` 不在で未実行 (CI / 開発機で再確認推奨)
- 既存構造に沿った実装で型整合性は静的に確認済み

## Self-Review (Codex)
信頼度: 中
- 9 キー全て実装、modifier collision / editable guard 対応
- スコープ逸脱無し (`src-tauri/` は触らず)
- Hide / Isolate / Unhide 系の interaction も unit test で確認済み
- 残課題: 実環境で vitest / tsc / eslint pass を確認