### PR TITLE
test: add viewport snapshot regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,14 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
 
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Run visual regression
         run: |
           npm run dev -- --host 127.0.0.1 > /tmp/vite-dev.log 2>&1 &
@@ -123,13 +131,17 @@ jobs:
           fi
 
           npm run test:visual -- http://127.0.0.1:1420/selftest.html tests/visual/snapshots/selftest-page-linux-chromium.png artifacts/screenshots/selftest-page-current.png
+          cleanup
+          trap - EXIT
+
+          xvfb-run -a npm run test:viewport-snapshot
 
       - name: Upload visual artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: selftest-visual-current
-          path: artifacts/screenshots/selftest-page-current.png
+          name: visual-regression-current
+          path: artifacts/screenshots/**/*.png
 
   rust-checks:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ experiments/
 
 # Local Claude Code session state
 .claude/
+
+# Husky generated helper scripts
+.husky/_/

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ npm run shot -- --in model.usdz --out shot.png --size 1920x1080 --bg transparent
 npm run shot:check -- --in model.fbx
 ```
 
-`--shot` / `--check` は内部的に `tauri dev` 上で `shot.html` を起動して描画 → 書き出し → 終了する。ビルド済みバイナリへの組み込みは現状未対応（bench と同じく dev 経由）。
+`--shot` / `--check` は内部的に Vite dev server と `cargo run` を起動し、`shot.html` で描画 → 書き出し → 終了する。ビルド済みバイナリへの組み込みは現状未対応（bench と同じく dev 経由）。
 
 ## コード品質
 
@@ -186,6 +186,12 @@ npm run test:integration -- http://127.0.0.1:1420/selftest.html
 
 # 別ターミナルでビジュアルリグレッション（snapshot 比較）
 npm run test:visual -- http://127.0.0.1:1420/selftest.html
+
+# viewport screenshot API 由来の PNG snapshot 比較
+npm run test:viewport-snapshot
+
+# viewport snapshot baseline 更新
+npm run test:viewport-snapshot:update
 ```
 
 ## ディレクトリ構成

--- a/ToDo.md
+++ b/ToDo.md
@@ -423,9 +423,9 @@ USD-view パリティの取り組みは tracking issue #27 配下で進める。
 
 - [x] 画面キャプチャの仕組みを調査する（Playwright で `selftest.html` を撮影）
 - [x] selftest ページのスナップショットテストを作る（`tests/visual/snapshots/selftest-page-linux-chromium.png`）
-- [ ] 各フォーマットを読み込んだ viewer 画面のスナップショットテストを作る
+- [ ] 各フォーマットを読み込んだ viewer 画面のスナップショットテストを作る（`test:viewport-snapshot` harness と `usda-tiny-sanity` baseline は追加済み。対象フォーマット拡張は後続）
 - [ ] エラー画面・空状態・ローディング状態のスナップショットテストを作る
-- [x] CI でスナップショットを比較できる仕組みを検討する（`visual-regression` job で selftest snapshot 比較）
+- [x] CI でスナップショットを比較できる仕組みを検討する（`visual-regression` job で selftest snapshot と viewport snapshot を比較）
 
 ### 起動スピードテスト（#54）
 
@@ -486,7 +486,7 @@ USD-view パリティの取り組みは tracking issue #27 配下で進める。
 
 - [x] WebGL レンダラーから現在のフレームを PNG として書き出す機能を作る（`src/viewer/screenshot.ts`）
 - [x] CLI として外部から呼び出せるスクリーンショット機能を公開する（`yw-look --shot --in <model> --out <png>` / `--check`。`shot.html` + `src/shot/` + Tauri commands `get_shot_config` / `write_shot_output` / `finish_shot_run`。`npm run shot -- --in ... --out ...` から起動）
-- [ ] テストから shot CLI 経由でスクリーンショットを取得してスナップショット比較に使う（現状は Playwright の page screenshot）
+- [x] テストから shot CLI 経由でスクリーンショットを取得してスナップショット比較に使う（`scripts/viewport-snapshot.mjs` + `tests/visual/snapshots/viewport/usda-tiny-sanity.png`）
 
 ## 24. 将来対応の検討（フォーマット・パフォーマンス）
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "test:batch": "node scripts/batch-load-test.mjs",
     "test:integration": "node scripts/run-selftest.mjs",
     "test:visual": "node scripts/visual-regression.mjs",
+    "test:viewport-snapshot": "node scripts/viewport-snapshot.mjs",
+    "test:viewport-snapshot:update": "node scripts/viewport-snapshot.mjs --update-snapshot",
     "samples:fetch": "node samples/private/fetch.mjs",
     "bench:load": "node scripts/run-load-bench.mjs",
     "shot": "node scripts/run-shot.mjs shot",

--- a/scripts/run-shot.mjs
+++ b/scripts/run-shot.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import http from "node:http";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -11,7 +12,7 @@ const usage = `usage:
   npm run shot -- --in <model> --out <png> [--size WxH] [--bg color]
   npm run check -- --in <model>
 
-Forwards extra args to the yw-look binary running under \`tauri dev\`.
+Forwards extra args to the yw-look binary running with a local Vite dev server.
 The first positional argument is treated as the subcommand
 (\`shot\` or \`check\`); other tokens are forwarded verbatim.`;
 
@@ -29,23 +30,107 @@ if (subcommand !== "shot" && subcommand !== "check") {
 }
 
 const forwarded = argv.slice(1);
-const args = ["tauri", "dev", "--", "--", `--${subcommand}`, ...forwarded];
+const cargoArgs = [
+  "run",
+  "--manifest-path",
+  path.join(repoRoot, "src-tauri/Cargo.toml"),
+];
+const cargoFeatures = process.env.YW_LOOK_CARGO_FEATURES;
+if (process.env.YW_LOOK_CARGO_NO_DEFAULT_FEATURES === "1") {
+  cargoArgs.push("--no-default-features");
+}
+if (cargoFeatures) {
+  cargoArgs.push("--features", cargoFeatures);
+}
+cargoArgs.push("--", `--${subcommand}`, ...forwarded);
 
-const child = spawn("npx", args, {
+function probeUrl(url) {
+  return new Promise((resolve) => {
+    const request = http.get(url, (response) => {
+      response.resume();
+      resolve(true);
+    });
+    request.on("error", () => resolve(false));
+    request.setTimeout(2_000, () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+}
+
+function waitForUrl(url, timeoutMs = 60_000) {
+  const startedAt = Date.now();
+  return new Promise((resolve, reject) => {
+    const poll = async () => {
+      if (await probeUrl(url)) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        reject(new Error(`dev server did not become ready: ${url}`));
+        return;
+      }
+      setTimeout(poll, 500);
+    };
+    poll();
+  });
+}
+
+const devUrl = "http://127.0.0.1:1420/shot.html";
+const reuseDevServer = await probeUrl(devUrl);
+const devServer = reuseDevServer
+  ? null
+  : spawn("npm", ["run", "dev", "--", "--host", "127.0.0.1"], {
+      cwd: repoRoot,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+function stopDevServer() {
+  if (!devServer || devServer.killed) {
+    return;
+  }
+  if (process.platform === "win32" && devServer.pid) {
+    spawn("taskkill", ["/pid", String(devServer.pid), "/T", "/F"], {
+      stdio: "ignore",
+      shell: false,
+    });
+    return;
+  }
+  devServer.kill();
+}
+
+devServer?.on("error", (error) => {
+  stopDevServer();
+  console.error(error);
+  process.exit(1);
+});
+
+try {
+  await waitForUrl(devUrl);
+} catch (error) {
+  stopDevServer();
+  console.error(error);
+  process.exit(1);
+}
+
+const child = spawn("cargo", cargoArgs, {
   cwd: repoRoot,
   stdio: "inherit",
   shell: process.platform === "win32",
 });
 
+child.on("error", (error) => {
+  stopDevServer();
+  console.error(error);
+  process.exit(1);
+});
+
 child.on("exit", (code, signal) => {
+  stopDevServer();
   if (signal) {
     process.kill(process.pid, signal);
     return;
   }
   process.exit(code ?? 1);
-});
-
-child.on("error", (error) => {
-  console.error(error);
-  process.exit(1);
 });

--- a/scripts/viewport-snapshot.mjs
+++ b/scripts/viewport-snapshot.mjs
@@ -1,0 +1,187 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { copyFile, mkdir, readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const cases = [
+  {
+    id: "usda-tiny-sanity",
+    input: "samples/assets/usd/tiny.usda",
+    snapshot: "tests/visual/snapshots/viewport/usda-tiny-sanity.png",
+    actual: "artifacts/screenshots/viewport/usda-tiny-sanity-current.png",
+    size: "640x480",
+    background: "default",
+  },
+];
+
+const usage = `usage:
+  npm run test:viewport-snapshot
+  npm run test:viewport-snapshot -- --case <id>
+  npm run test:viewport-snapshot:update
+  UPDATE_SNAPSHOTS=1 npm run test:viewport-snapshot
+
+Options:
+  --case <id>          Run one viewport snapshot case.
+  --update-snapshot    Replace baselines with the newly rendered PNGs.
+  --list               Print available cases without running shot CLI.`;
+
+const args = process.argv.slice(2);
+const updateSnapshots =
+  process.env.UPDATE_SNAPSHOTS === "1" || args.includes("--update-snapshot");
+const listOnly = args.includes("--list");
+
+function readOption(name) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return null;
+  }
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(usage);
+  process.exit(0);
+}
+
+let selectedCases = cases;
+try {
+  const selectedCaseId = readOption("--case");
+  if (selectedCaseId) {
+    selectedCases = cases.filter((testCase) => testCase.id === selectedCaseId);
+    if (selectedCases.length === 0) {
+      throw new Error(`unknown viewport snapshot case: ${selectedCaseId}`);
+    }
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error(usage);
+  process.exit(2);
+}
+
+if (listOnly) {
+  for (const testCase of selectedCases) {
+    console.log(`${testCase.id}: ${testCase.input}`);
+  }
+  process.exit(0);
+}
+
+function resolveRepoPath(repoPath) {
+  return path.resolve(repoRoot, repoPath);
+}
+
+function sha256(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function compareExact(actualBuffer, expectedBuffer) {
+  return Buffer.compare(actualBuffer, expectedBuffer) === 0;
+}
+
+function runShot(testCase) {
+  const shotArgs = [
+    path.join(repoRoot, "scripts/run-shot.mjs"),
+    "shot",
+    "--in",
+    resolveRepoPath(testCase.input),
+    "--out",
+    resolveRepoPath(testCase.actual),
+    "--size",
+    testCase.size,
+    "--bg",
+    testCase.background,
+  ];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, shotArgs, {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        YW_LOOK_CARGO_NO_DEFAULT_FEATURES:
+          process.env.YW_LOOK_CARGO_NO_DEFAULT_FEATURES ?? "1",
+        YW_LOOK_CARGO_FEATURES:
+          process.env.YW_LOOK_CARGO_FEATURES ?? "backend-openusd-rs",
+      },
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`shot CLI was terminated by ${signal}`));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(`shot CLI exited with code ${code ?? 1}`));
+        return;
+      }
+      resolve();
+    });
+
+    child.on("error", reject);
+  });
+}
+
+async function compareSnapshot(testCase) {
+  const actualPath = resolveRepoPath(testCase.actual);
+  const snapshotPath = resolveRepoPath(testCase.snapshot);
+  const actualBuffer = await readFile(actualPath);
+
+  if (updateSnapshots) {
+    await mkdir(path.dirname(snapshotPath), { recursive: true });
+    await copyFile(actualPath, snapshotPath);
+    console.log(`Updated viewport snapshot: ${testCase.snapshot}`);
+    return;
+  }
+
+  let expectedBuffer;
+  try {
+    expectedBuffer = await readFile(snapshotPath);
+  } catch {
+    throw new Error(
+      `Snapshot not found at ${testCase.snapshot}. Run UPDATE_SNAPSHOTS=1 npm run test:viewport-snapshot first.`,
+    );
+  }
+
+  if (!compareExact(actualBuffer, expectedBuffer)) {
+    throw new Error(
+      [
+        `Viewport snapshot mismatch: ${testCase.id}`,
+        `expected sha256: ${sha256(expectedBuffer)}`,
+        `actual   sha256: ${sha256(actualBuffer)}`,
+        `actual image: ${testCase.actual}`,
+      ].join("\n"),
+    );
+  }
+
+  console.log(`Viewport snapshot matched: ${testCase.id}`);
+}
+
+let failed = false;
+for (const testCase of selectedCases) {
+  try {
+    await mkdir(path.dirname(resolveRepoPath(testCase.actual)), {
+      recursive: true,
+    });
+    await rm(resolveRepoPath(testCase.actual), { force: true });
+    console.log(`Rendering viewport snapshot: ${testCase.id}`);
+    await runShot(testCase);
+    await compareSnapshot(testCase);
+  } catch (error) {
+    failed = true;
+    console.error(error instanceof Error ? error.message : String(error));
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}

--- a/src/components/AssetViewport.tsx
+++ b/src/components/AssetViewport.tsx
@@ -234,7 +234,10 @@ function selectionKeyForObject(object: Object3D) {
   return primPath ?? (raw.length > 0 ? raw : null);
 }
 
-function findObjectBySelectionKey(root: Object3D, selectionKey: string) {
+function findObjectBySelectionKey(
+  root: Object3D,
+  selectionKey: string,
+): Object3D | null {
   let match: Object3D | null = null;
 
   root.traverse((child) => {
@@ -261,8 +264,7 @@ function frameObjectBounds(
   const center = bounds.getCenter(new Vector3());
   const maxDimension = Math.max(size.x, size.y, size.z, 0.001);
   const fitHeightDistance =
-    maxDimension /
-    (2 * Math.tan(MathUtils.degToRad(context.camera.fov * 0.5)));
+    maxDimension / (2 * Math.tan(MathUtils.degToRad(context.camera.fov * 0.5)));
   const fitDistance = fitHeightDistance * 1.5;
   const direction = context.camera.position
     .clone()
@@ -283,7 +285,11 @@ function frameObjectBounds(
   context.controls.target.copy(center);
   context.controls.minDistance = Math.max(maxDimension / 50, 0.05);
   context.controls.maxDistance = Math.max(maxDimension * 40, 50);
-  applyControlsSensitivity(context.controls, maxDimension, sensitivityMultiplier);
+  applyControlsSensitivity(
+    context.controls,
+    maxDimension,
+    sensitivityMultiplier,
+  );
   context.controls.update();
   context.controls.enabled = true;
 }
@@ -2357,11 +2363,7 @@ export function AssetViewport({
         );
         if (target) {
           configureAssetControls(context.controls);
-          frameObjectBounds(
-            context,
-            target,
-            cameraSpeedMultiplierRef.current,
-          );
+          frameObjectBounds(context, target, cameraSpeedMultiplierRef.current);
         }
         return;
       }

--- a/src/lib/__tests__/viewerShortcuts.test.ts
+++ b/src/lib/__tests__/viewerShortcuts.test.ts
@@ -10,10 +10,7 @@ import type { DisplayMode } from "../../viewer";
 function event(
   key: string,
   modifiers: Partial<KeyboardEvent> = {},
-): Pick<
-  KeyboardEvent,
-  "key" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
-> {
+): Pick<KeyboardEvent, "key" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey"> {
   return {
     key,
     altKey: Boolean(modifiers.altKey),
@@ -128,7 +125,7 @@ describe("viewer shortcuts", () => {
     );
 
     const editable = document.createElement("div");
-    editable.contentEditable = "true";
+    editable.setAttribute("contenteditable", "true");
     expect(isEditableShortcutTarget(editable)).toBe(true);
   });
 

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -1,0 +1,28 @@
+# Visual regression tests
+
+`npm run test:visual` captures the `selftest.html` page through Playwright and
+compares it with `tests/visual/snapshots/selftest-page-linux-chromium.png`.
+
+`npm run test:viewport-snapshot` renders a representative 3D viewport through the
+shot CLI and compares the generated PNG with
+`tests/visual/snapshots/viewport/usda-tiny-sanity.png`.
+
+The viewport snapshot case uses `samples/assets/usd/tiny.usda` and writes the
+current render to `artifacts/screenshots/viewport/usda-tiny-sanity-current.png`.
+On mismatch, keep that actual image for review.
+
+To update viewport baselines after an intentional rendering change:
+
+```bash
+UPDATE_SNAPSHOTS=1 npm run test:viewport-snapshot
+```
+
+or:
+
+```bash
+npm run test:viewport-snapshot:update
+```
+
+The comparison is currently an exact PNG byte match. If CI proves flaky across
+GPU drivers or OS images, keep `scripts/viewport-snapshot.mjs` as the harness and
+replace the isolated comparison function with a threshold-based PNG diff.

--- a/tests/visual/snapshots/viewport/usda-tiny-sanity.png
+++ b/tests/visual/snapshots/viewport/usda-tiny-sanity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29b7991d876da492f068cc7eeeb8c4c5c39ca776c8e4d2394c13ae4ad5250219
+size 7981


### PR DESCRIPTION
## Summary

- Add a viewport screenshot visual regression harness that renders `samples/assets/usd/tiny.usda` through the shot CLI and compares the API-derived PNG against a committed baseline.
- Add `test:viewport-snapshot` and `test:viewport-snapshot:update` npm scripts, baseline documentation, and CI wiring in the visual-regression job.
- Update the shot runner to use a local Vite dev server plus `cargo run`, with Rust backend feature overrides for CI-friendly snapshot execution.
- Update `ToDo.md` to mark the shot CLI snapshot comparison path complete for the representative baseline.

## Validation

- `npm run test:viewport-snapshot`
- `npm run test -- src/lib/__tests__/viewerShortcuts.test.ts`
- `npm run format:check`
- `npm run lint` (passes with existing React hooks warnings)
- `tsc --noEmit`
- `tsc --noEmit -p tsconfig.node.json`

## Review Notes

Codex review initially flagged a dev-server cleanup issue in `scripts/run-shot.mjs`; this PR includes the fix. A follow-up review attempt was blocked by approval policy for external diff disclosure.

Closes #49