### PR TITLE
[codex] Suppress resolved nested Kitchen payload warnings

### DIFF
--- a/src-tauri/src/usd/openusd_backend.rs
+++ b/src-tauri/src/usd/openusd_backend.rs
@@ -8,7 +8,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashSet;
-use std::path::Path as StdPath;
+use std::path::{Path as StdPath, PathBuf};
 
 use openusd::sdf::schema::FieldKey;
 use openusd::sdf::{Path as SdfPath, Value as SdfValue};
@@ -50,6 +50,74 @@ fn to_openusd_policy(policy: StageLoadPolicy) -> OpenusdLoadPolicy {
         StageLoadPolicy::LoadAll => OpenusdLoadPolicy::LoadAll,
         StageLoadPolicy::NoPayloads => OpenusdLoadPolicy::NoPayloads,
     }
+}
+
+pub(crate) fn filter_resolvable_relative_assets(
+    root_path: &StdPath,
+    layer_ids: impl IntoIterator<Item = String>,
+    unresolved_assets: Vec<String>,
+) -> Vec<String> {
+    let mut layer_paths = Vec::<PathBuf>::new();
+    layer_paths.push(root_path.to_path_buf());
+    for layer_id in layer_ids {
+        let layer_path = StdPath::new(&layer_id);
+        if layer_path.as_os_str().is_empty() || layer_paths.iter().any(|path| path == layer_path) {
+            continue;
+        }
+        layer_paths.push(layer_path.to_path_buf());
+    }
+
+    unresolved_assets
+        .into_iter()
+        .filter(|asset| {
+            let authored_path = StdPath::new(asset);
+            let exists = if authored_path.is_absolute() {
+                authored_path.is_file()
+            } else {
+                relative_asset_resolves_for_every_authored_layer(&layer_paths, authored_path, asset)
+            };
+            !exists
+        })
+        .collect()
+}
+
+// `unresolved_assets` only reports authored asset strings, not the source
+// layer. Keep this conservative: suppress only when every visible layer that
+// authors the exact `@asset@` token can resolve it next to that layer.
+fn relative_asset_resolves_for_every_authored_layer(
+    layer_paths: &[PathBuf],
+    authored_path: &StdPath,
+    asset_path: &str,
+) -> bool {
+    let mut saw_authored_layer = false;
+    for layer_path in layer_paths {
+        if !layer_authors_asset_token(layer_path, asset_path) {
+            continue;
+        }
+        saw_authored_layer = true;
+        let Some(layer_dir) = layer_path.parent() else {
+            return false;
+        };
+        if !layer_dir.join(authored_path).is_file() {
+            return false;
+        }
+    }
+    saw_authored_layer
+}
+
+fn layer_authors_asset_token(layer_path: &StdPath, asset_path: &str) -> bool {
+    let Ok(bytes) = std::fs::read(layer_path) else {
+        return false;
+    };
+    let needle = asset_path.as_bytes();
+    if needle.is_empty() || bytes.len() < needle.len() + 2 {
+        return false;
+    }
+    bytes.windows(needle.len() + 2).any(|window| {
+        window.first() == Some(&b'@')
+            && window.last() == Some(&b'@')
+            && &window[1..window.len() - 1] == needle
+    })
 }
 
 /// Real backend backed by `openusd`.
@@ -122,6 +190,11 @@ impl UsdInspectBackend for OpenusdBackend {
         // composition (references, payloads, sublayers) — not just authored
         // `subLayers` arcs — which is what the frontend actually needs.
         let layer_ids = stage.layer_identifiers();
+        let missing_assets = filter_resolvable_relative_assets(
+            path,
+            layer_ids.iter().cloned(),
+            stage.unresolved_assets(),
+        );
         let composed_layers: Vec<String> = layer_ids.into_iter().skip(1).collect();
 
         // Capture unresolved assets upfront so each composition arc can be
@@ -129,7 +202,6 @@ impl UsdInspectBackend for OpenusdBackend {
         // exact-string matching as `collect_asset_issues` — any arc whose
         // authored `assetPath` appears in `unresolved_assets()` is reported
         // as `Missing`, everything else is `Loaded`.
-        let missing_assets = stage.unresolved_assets();
         let unresolved_set: HashSet<&str> = missing_assets.iter().map(String::as_str).collect();
 
         // Phase 4: collect the payload arcs the layer collector skipped
@@ -318,7 +390,11 @@ impl UsdInspectBackend for OpenusdBackend {
 
         // #38: build unresolved-asset set upfront so arc classification
         // in the traverse closure can borrow it without moving `stage`.
-        let unresolved_assets = stage.unresolved_assets();
+        let unresolved_assets = filter_resolvable_relative_assets(
+            path,
+            stage.layer_identifiers(),
+            stage.unresolved_assets(),
+        );
         let unresolved_set: HashSet<&str> = unresolved_assets.iter().map(String::as_str).collect();
 
         // #38: skipped payloads for NoPayloads policy classification.
@@ -518,7 +594,11 @@ impl UsdInspectBackend for OpenusdBackend {
             }
         }
 
-        let unresolved_owned = stage.unresolved_assets();
+        let unresolved_owned = filter_resolvable_relative_assets(
+            path,
+            stage.layer_identifiers(),
+            stage.unresolved_assets(),
+        );
         let unresolved: HashSet<&str> = unresolved_owned.iter().map(|s| s.as_str()).collect();
 
         let collected: RefCell<Vec<AssetIssue>> = RefCell::new(Vec::new());
@@ -4637,6 +4717,162 @@ mod tests {
         std::fs::read_to_string(path)
             .map(|s| s.starts_with("version https://git-lfs.github.com/spec/v1"))
             .unwrap_or(false)
+    }
+
+    #[test]
+    fn filters_relative_unresolved_assets_that_exist_next_to_composed_layers() {
+        let root =
+            std::env::temp_dir().join(format!("yw-look-filter-assets-{}", std::process::id()));
+        let layer_dir = root.join("assets").join("Kitchen");
+        std::fs::create_dir_all(&layer_dir).expect("create layer dir");
+        let root_layer = root.join("Kitchen_set.usd");
+        let layer = layer_dir.join("Kitchen.usd");
+        let payload = layer_dir.join("Kitchen_payload.usd");
+        std::fs::write(&root_layer, "#usda 1.0").expect("write root layer");
+        std::fs::write(
+            &layer,
+            r#"#usda 1.0
+def "Kitchen"
+{
+    payload = @./Kitchen_payload.usd@
+}
+"#,
+        )
+        .expect("write layer");
+        std::fs::write(&payload, "#usda 1.0").expect("write payload");
+
+        let unresolved = filter_resolvable_relative_assets(
+            &root_layer,
+            vec![
+                root_layer.display().to_string(),
+                layer.display().to_string(),
+            ],
+            vec![
+                "./Kitchen_payload.usd".to_string(),
+                "./ActuallyMissing_payload.usd".to_string(),
+            ],
+        );
+
+        assert_eq!(unresolved, vec!["./ActuallyMissing_payload.usd"]);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn leaves_relative_unresolved_asset_when_only_another_layer_has_the_file() {
+        let root = std::env::temp_dir().join(format!(
+            "yw-look-filter-assets-negative-{}",
+            std::process::id()
+        ));
+        let missing_layer_dir = root.join("assets").join("A");
+        let unrelated_layer_dir = root.join("assets").join("B");
+        std::fs::create_dir_all(&missing_layer_dir).expect("create missing layer dir");
+        std::fs::create_dir_all(&unrelated_layer_dir).expect("create unrelated layer dir");
+        let root_layer = root.join("Root.usd");
+        let missing_layer = missing_layer_dir.join("A.usd");
+        let unrelated_layer = unrelated_layer_dir.join("B.usd");
+        let unrelated_payload = unrelated_layer_dir.join("Shared_payload.usd");
+        std::fs::write(&root_layer, "#usda 1.0").expect("write root layer");
+        std::fs::write(
+            &missing_layer,
+            r#"#usda 1.0
+def "A"
+{
+    payload = @./Shared_payload.usd@
+}
+"#,
+        )
+        .expect("write missing layer");
+        std::fs::write(&unrelated_layer, "#usda 1.0").expect("write unrelated layer");
+        std::fs::write(&unrelated_payload, "#usda 1.0").expect("write unrelated payload");
+
+        let unresolved = filter_resolvable_relative_assets(
+            &root_layer,
+            vec![
+                root_layer.display().to_string(),
+                missing_layer.display().to_string(),
+                unrelated_layer.display().to_string(),
+            ],
+            vec!["./Shared_payload.usd".to_string()],
+        );
+
+        assert_eq!(unresolved, vec!["./Shared_payload.usd"]);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn leaves_relative_unresolved_asset_when_any_authoring_layer_is_missing_the_file() {
+        let root = std::env::temp_dir().join(format!(
+            "yw-look-filter-assets-partial-{}",
+            std::process::id()
+        ));
+        let missing_layer_dir = root.join("assets").join("A");
+        let resolved_layer_dir = root.join("assets").join("B");
+        std::fs::create_dir_all(&missing_layer_dir).expect("create missing layer dir");
+        std::fs::create_dir_all(&resolved_layer_dir).expect("create resolved layer dir");
+        let root_layer = root.join("Root.usd");
+        let missing_layer = missing_layer_dir.join("A.usd");
+        let resolved_layer = resolved_layer_dir.join("B.usd");
+        let resolved_payload = resolved_layer_dir.join("Shared_payload.usd");
+        std::fs::write(&root_layer, "#usda 1.0").expect("write root layer");
+        let layer_text = r#"#usda 1.0
+def "Shared"
+{
+    payload = @./Shared_payload.usd@
+}
+"#;
+        std::fs::write(&missing_layer, layer_text).expect("write missing layer");
+        std::fs::write(&resolved_layer, layer_text).expect("write resolved layer");
+        std::fs::write(&resolved_payload, "#usda 1.0").expect("write resolved payload");
+
+        let unresolved = filter_resolvable_relative_assets(
+            &root_layer,
+            vec![
+                root_layer.display().to_string(),
+                missing_layer.display().to_string(),
+                resolved_layer.display().to_string(),
+            ],
+            vec!["./Shared_payload.usd".to_string()],
+        );
+
+        assert_eq!(unresolved, vec!["./Shared_payload.usd"]);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn leaves_relative_unresolved_asset_when_path_is_only_a_substring() {
+        let root = std::env::temp_dir().join(format!(
+            "yw-look-filter-assets-token-{}",
+            std::process::id()
+        ));
+        let layer_dir = root.join("assets");
+        std::fs::create_dir_all(&layer_dir).expect("create layer dir");
+        let root_layer = root.join("Root.usd");
+        let layer = layer_dir.join("Layer.usd");
+        let payload = layer_dir.join("Payload.usd");
+        std::fs::write(&root_layer, "#usda 1.0").expect("write root layer");
+        std::fs::write(
+            &layer,
+            r#"#usda 1.0
+def "Layer"
+{
+    payload = @./Payload.usda@
+}
+"#,
+        )
+        .expect("write layer");
+        std::fs::write(&payload, "#usda 1.0").expect("write payload");
+
+        let unresolved = filter_resolvable_relative_assets(
+            &root_layer,
+            vec![
+                root_layer.display().to_string(),
+                layer.display().to_string(),
+            ],
+            vec!["./Payload.usd".to_string()],
+        );
+
+        assert_eq!(unresolved, vec!["./Payload.usd"]);
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/src-tauri/src/usd/openusd_cpp_backend.rs
+++ b/src-tauri/src/usd/openusd_cpp_backend.rs
@@ -31,12 +31,12 @@ use super::backend::{
 };
 use super::cpp_sys::{CError, CStage, Interpolation, LoadPolicy, Orientation, UpAxis};
 use super::glb::{self, AlphaMode, InstancingInput, MaterialInput, MeshInput};
-use super::openusd_backend::DenseBlendShape;
 use super::openusd_backend::{
     filter_mesh_by_face_indices, invert_mat4_f32, mat4_f64_to_f32, mat4_mul, mat4_mul_f32,
     mesh_data_to_input, remap_mesh_skin_indices, srgb_to_linear, usd_wrap_to_gltf,
     z_up_to_y_up_mat4, MeshOrientation,
 };
+use super::openusd_backend::{filter_resolvable_relative_assets, DenseBlendShape};
 use super::types::{
     AssetIssue, AssetIssueCode, AssetIssueLevel, AttributeInfo, AttributeTimeSamples,
     CompositionArc, CompositionArcKind, CompositionArcState, ExtractGeometryOptions, LayerInfo,
@@ -136,13 +136,18 @@ impl UsdInspectBackend for OpenusdCppBackend {
         // Layer identifiers: first entry is the root layer, everything
         // after are composed dependencies. The inspector UI only shows
         // the composed set (sublayers, refs, payloads), so skip [0].
-        let mut layer_ids = stage.layer_identifiers().map_err(map_c_error)?;
+        let all_layer_ids = stage.layer_identifiers().map_err(map_c_error)?;
+        let missing_assets = filter_resolvable_relative_assets(
+            path,
+            all_layer_ids.iter().cloned(),
+            stage.unresolved_assets().map_err(map_c_error)?,
+        );
+        let mut layer_ids = all_layer_ids;
         if !layer_ids.is_empty() {
             layer_ids.remove(0);
         }
         let composed_layers = layer_ids;
 
-        let missing_assets = stage.unresolved_assets().map_err(map_c_error)?;
         let unresolved_set: HashSet<&str> = missing_assets.iter().map(String::as_str).collect();
 
         // Skipped-payloads key on (asset_path, source_prim) — see
@@ -318,7 +323,11 @@ impl UsdInspectBackend for OpenusdCppBackend {
         let mut prim_type_counts: Vec<PrimTypeCount> = Vec::new();
 
         // #38: unresolved assets set for arc classification.
-        let unresolved_assets = stage.unresolved_assets().map_err(map_c_error)?;
+        let unresolved_assets = filter_resolvable_relative_assets(
+            path,
+            stage.layer_identifiers().map_err(map_c_error)?,
+            stage.unresolved_assets().map_err(map_c_error)?,
+        );
         let unresolved_set: HashSet<&str> = unresolved_assets.iter().map(String::as_str).collect();
 
         // #38: skipped payloads for NoPayloads policy classification.
@@ -461,7 +470,11 @@ impl UsdInspectBackend for OpenusdCppBackend {
             }
         }
 
-        let unresolved_owned = stage.unresolved_assets().map_err(map_c_error)?;
+        let unresolved_owned = filter_resolvable_relative_assets(
+            path,
+            stage.layer_identifiers().map_err(map_c_error)?,
+            stage.unresolved_assets().map_err(map_c_error)?,
+        );
         let unresolved_set: HashSet<&str> = unresolved_owned.iter().map(String::as_str).collect();
 
         // Walk arcs and emit one contextualized issue per missing

--- a/src-tauri/tests/private_kitchen_payload_warnings.rs
+++ b/src-tauri/tests/private_kitchen_payload_warnings.rs
@@ -1,0 +1,48 @@
+//! Private regression checks for false-positive Kitchen Set payload warnings.
+//!
+//! The Pixar Kitchen Set sample is ignored under `samples/private`, so this
+//! test skips when the local sample has not been fetched.
+
+#![cfg(feature = "backend-openusd-rs")]
+
+use std::path::PathBuf;
+
+use yw_look_lib::usd::{OpenusdBackend, UsdInspectBackend};
+
+fn kitchen_set_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("samples")
+        .join("private")
+        .join("usd")
+        .join("Kitchen_set")
+        .join("Kitchen_set.usd")
+}
+
+#[test]
+fn kitchen_set_payload_files_are_not_reported_missing() {
+    let path = kitchen_set_path();
+    if !path.exists() {
+        eprintln!(
+            "Skipping private Kitchen Set payload warning test: {}",
+            path.display()
+        );
+        return;
+    }
+
+    let backend = OpenusdBackend::new();
+    let issues = backend
+        .collect_asset_issues(&path)
+        .expect("collect Kitchen Set asset issues");
+    let missing_payloads: Vec<_> = issues
+        .iter()
+        .filter(|issue| issue.message.starts_with("Missing payload:"))
+        .map(|issue| issue.message.as_str())
+        .collect();
+
+    assert!(
+        missing_payloads.is_empty(),
+        "existing nested Kitchen Set payloads must not be reported missing: {:?}",
+        missing_payloads
+    );
+}


### PR DESCRIPTION
## Summary
- suppress false Missing payload warnings when OpenUSD reports an authored relative asset that resolves next to its composed layer
- apply the filtering to Rust and C++ USD inspection paths
- add conservative unit coverage plus a private Kitchen Set regression check

## Validation
- rustfmt --check src-tauri/src/usd/openusd_backend.rs src-tauri/src/usd/openusd_cpp_backend.rs src-tauri/tests/private_kitchen_payload_warnings.rs
- cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --features backend-openusd-rs relative_unresolved_asset
- cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --features backend-openusd-rs --test private_kitchen_payload_warnings -- --nocapture
- npx tsc --noEmit

## Notes
- The filter is intentionally conservative: it only suppresses unresolved relative assets when every visible layer authoring the exact @asset@ token has the file next to that layer.